### PR TITLE
perf: debounce UI renders with requestAnimationFrame

### DIFF
--- a/cmd/claude-monitor/static/index.html
+++ b/cmd/claude-monitor/static/index.html
@@ -1953,8 +1953,31 @@ function isActive(session) {
   return (Date.now() - new Date(session.lastActive).getTime()) < 30_000;
 }
 
-// ── Top bar ────────────────────────────────────────────────────
+// ── Debounced rendering ─────────────────────────────────────────
+// Coalesce rapid-fire WS messages into one render per animation frame.
+let _renderRAF = 0;
+let _topBarRAF = 0;
+
+function renderSessions() {
+  if (!_renderRAF) {
+    _renderRAF = requestAnimationFrame(() => {
+      _renderRAF = 0;
+      _renderSessionsNow();
+    });
+  }
+}
+
 function updateTopBar() {
+  if (!_topBarRAF) {
+    _topBarRAF = requestAnimationFrame(() => {
+      _topBarRAF = 0;
+      _updateTopBarNow();
+    });
+  }
+}
+
+// ── Top bar ────────────────────────────────────────────────────
+function _updateTopBarNow() {
   const sessions = Object.values(state.sessions);
   const activeSessions = sessions.filter(isActive);
 
@@ -2024,7 +2047,7 @@ function updateFilterCounts() {
 }
 
 // ── Sessions list ──────────────────────────────────────────────
-function renderSessions() {
+function _renderSessionsNow() {
   const list = document.getElementById('sessions-list');
   const noSess = document.getElementById('no-sessions');
   const allSessions = Object.values(state.sessions)

--- a/static/index.html
+++ b/static/index.html
@@ -1953,8 +1953,31 @@ function isActive(session) {
   return (Date.now() - new Date(session.lastActive).getTime()) < 30_000;
 }
 
-// ── Top bar ────────────────────────────────────────────────────
+// ── Debounced rendering ─────────────────────────────────────────
+// Coalesce rapid-fire WS messages into one render per animation frame.
+let _renderRAF = 0;
+let _topBarRAF = 0;
+
+function renderSessions() {
+  if (!_renderRAF) {
+    _renderRAF = requestAnimationFrame(() => {
+      _renderRAF = 0;
+      _renderSessionsNow();
+    });
+  }
+}
+
 function updateTopBar() {
+  if (!_topBarRAF) {
+    _topBarRAF = requestAnimationFrame(() => {
+      _topBarRAF = 0;
+      _updateTopBarNow();
+    });
+  }
+}
+
+// ── Top bar ────────────────────────────────────────────────────
+function _updateTopBarNow() {
   const sessions = Object.values(state.sessions);
   const activeSessions = sessions.filter(isActive);
 
@@ -2024,7 +2047,7 @@ function updateFilterCounts() {
 }
 
 // ── Sessions list ──────────────────────────────────────────────
-function renderSessions() {
+function _renderSessionsNow() {
   const list = document.getElementById('sessions-list');
   const noSess = document.getElementById('no-sessions');
   const allSessions = Object.values(state.sessions)


### PR DESCRIPTION
## Summary
- Wrap `renderSessions()` and `updateTopBar()` in `requestAnimationFrame`-based debounce so rapid-fire WebSocket messages coalesce into a single DOM rebuild per frame (~16ms)
- Eliminates redundant full DOM rebuilds when multiple agents are active and generating high message throughput
- Zero perceptible latency — RAF fires on the next paint, keeping the UI feeling real-time

## Test plan
- [ ] Open dashboard with multiple active agents and verify sessions panel remains responsive
- [ ] Confirm active filter counts and top bar stats still update in real-time
- [ ] Verify no visual lag when new agents appear or sessions transition states

🤖 Generated with [Claude Code](https://claude.com/claude-code)