### PR TITLE
feat: vertical HTML timeline replacing canvas Gantt chart

### DIFF
--- a/web/src/components/timeline-view.ts
+++ b/web/src/components/timeline-view.ts
@@ -1,6 +1,7 @@
 // web/src/components/timeline-view.ts
-import { escapeHtml, formatDurationSecs } from '../utils';
+import { formatDurationSecs } from '../utils';
 import '../styles/views.css';
+import '../styles/feed.css';
 
 interface TimelineEvent {
   index: number;
@@ -22,20 +23,10 @@ const TYPE_COLORS: Record<string, string> = {
   system: '#444',
 };
 
-const LANE_LABELS = ['User', 'Assistant', 'Tools'];
+const PREVIEW_LEN = 120;
 
 let container: HTMLElement | null = null;
-let canvas: HTMLCanvasElement | null = null;
-let ctx: CanvasRenderingContext2D | null = null;
-let tooltip: HTMLElement | null = null;
 let events: TimelineEvent[] = [];
-
-// View state
-let offsetX = 0;
-let pixelsPerMs = 0.05; // zoom level
-let isDragging = false;
-let dragStartX = 0;
-let dragStartOffset = 0;
 
 export function render(mount: HTMLElement): void {
   container = mount;
@@ -60,220 +51,107 @@ async function loadEvents(sid: string): Promise<void> {
   }
 }
 
+function resolveType(evt: TimelineEvent): string {
+  if (evt.toolName && evt.role === 'assistant') return 'tool_use';
+  if (evt.toolName && evt.role === 'tool') return 'tool_result';
+  if (evt.type === 'error') return 'error';
+  return evt.role || evt.type || 'system';
+}
+
+function formatTime(ts: string): string {
+  const d = new Date(ts);
+  const h = String(d.getHours()).padStart(2, '0');
+  const m = String(d.getMinutes()).padStart(2, '0');
+  const s = String(d.getSeconds()).padStart(2, '0');
+  return `${h}:${m}:${s}`;
+}
+
 function show(): void {
   if (!container) return;
   container.innerHTML = '';
 
   const wrapper = document.createElement('div');
-  wrapper.className = 'timeline-container';
+  wrapper.className = 'vtimeline-container';
 
-  canvas = document.createElement('canvas');
-  wrapper.appendChild(canvas);
-
-  tooltip = document.createElement('div');
-  tooltip.className = 'timeline-tooltip';
-  wrapper.appendChild(tooltip);
-
-  container.appendChild(wrapper);
-
-  resizeCanvas();
-  window.addEventListener('resize', resizeCanvas);
-  canvas.addEventListener('mousedown', onMouseDown);
-  canvas.addEventListener('mousemove', onMouseMove);
-  canvas.addEventListener('mouseup', onMouseUp);
-  canvas.addEventListener('mouseleave', onMouseUp);
-  canvas.addEventListener('wheel', onWheel, { passive: false });
-
-  // Reset view
-  offsetX = 0;
-  if (events.length > 1) {
-    const t0 = new Date(events[0].timestamp).getTime();
-    const t1 = new Date(events[events.length - 1].timestamp).getTime();
-    const span = t1 - t0;
-    if (span > 0 && canvas) {
-      pixelsPerMs = (canvas.width - 40) / span;
-    }
-  }
-
-  draw();
-}
-
-function resizeCanvas(): void {
-  if (!canvas || !container) return;
-  canvas.width = container.clientWidth;
-  canvas.height = container.clientHeight;
-  ctx = canvas.getContext('2d');
-  draw();
-}
-
-function getLane(evt: TimelineEvent): number {
-  if (evt.role === 'user') return 0;
-  if (evt.toolName || evt.type === 'tool_use' || evt.type === 'tool_result') return 2;
-  return 1; // assistant, hook, system, etc.
-}
-
-function getColor(evt: TimelineEvent): string {
-  if (evt.toolName && evt.role === 'assistant') return TYPE_COLORS.tool_use;
-  if (evt.toolName && evt.role === 'tool') return TYPE_COLORS.tool_result;
-  return TYPE_COLORS[evt.role] || TYPE_COLORS[evt.type] || TYPE_COLORS.system;
-}
-
-function draw(): void {
-  if (!ctx || !canvas || events.length === 0) return;
-  const w = canvas.width, h = canvas.height;
-  ctx.clearRect(0, 0, w, h);
-
-  const laneH = (h - 30) / 3; // 30px for top time labels
-  const topY = 30;
-
-  // Draw lane backgrounds
-  ctx.fillStyle = 'rgba(255,255,255,0.02)';
-  for (let i = 0; i < 3; i++) {
-    if (i % 2 === 0) ctx.fillRect(0, topY + i * laneH, w, laneH);
-  }
-
-  // Draw lane labels
-  ctx.fillStyle = '#44445a';
-  ctx.font = '10px monospace';
-  ctx.textAlign = 'left';
-  for (let i = 0; i < LANE_LABELS.length; i++) {
-    ctx.fillText(LANE_LABELS[i], 4, topY + i * laneH + 14);
-  }
-
-  if (events.length < 2) return;
-
-  const t0 = new Date(events[0].timestamp).getTime();
-
-  // Draw time axis labels
-  ctx.fillStyle = '#44445a';
-  ctx.font = '9px monospace';
-  ctx.textAlign = 'center';
-  const step = Math.max(1000, Math.pow(10, Math.floor(Math.log10(1 / pixelsPerMs * 100))));
-  for (let t = 0; ; t += step) {
-    const x = t * pixelsPerMs + offsetX;
-    if (x > w) break;
-    if (x < 0) continue;
-    ctx.fillText(formatDurationSecs(t / 1000), x, 14);
-    ctx.strokeStyle = 'rgba(255,255,255,0.05)';
-    ctx.beginPath();
-    ctx.moveTo(x, 20);
-    ctx.lineTo(x, h);
-    ctx.stroke();
-  }
-
-  // Draw events as bars
-  for (let i = 0; i < events.length; i++) {
-    const evt = events[i];
-    const ts = new Date(evt.timestamp).getTime();
-    const nextTs = i < events.length - 1 ? new Date(events[i + 1].timestamp).getTime() : ts + 1000;
-    const duration = Math.max(nextTs - ts, 200); // min 200ms for visibility
-
-    const x = (ts - t0) * pixelsPerMs + offsetX;
-    const barW = Math.max(duration * pixelsPerMs, 4);
-    const lane = getLane(evt);
-    const y = topY + lane * laneH + 4;
-    const barH = laneH - 8;
-
-    if (x + barW < 0 || x > w) continue; // off screen
-
-    ctx.fillStyle = getColor(evt);
-    ctx.globalAlpha = 0.7;
-    ctx.fillRect(x, y, barW, barH);
-    ctx.globalAlpha = 1;
-
-    // Label inside bar if wide enough
-    if (barW > 40) {
-      const label = evt.toolName || evt.role || '';
-      ctx.fillStyle = '#000';
-      ctx.font = '9px monospace';
-      ctx.textAlign = 'left';
-      ctx.fillText(label.slice(0, Math.floor(barW / 6)), x + 3, y + barH / 2 + 3);
-    }
-  }
-}
-
-function getEventAt(mx: number, my: number): TimelineEvent | null {
-  if (events.length < 2 || !canvas) return null;
-  const h = canvas.height;
-  const laneH = (h - 30) / 3;
-  const topY = 30;
-  const t0 = new Date(events[0].timestamp).getTime();
-
-  for (let i = 0; i < events.length; i++) {
-    const evt = events[i];
-    const ts = new Date(evt.timestamp).getTime();
-    const nextTs = i < events.length - 1 ? new Date(events[i + 1].timestamp).getTime() : ts + 1000;
-    const duration = Math.max(nextTs - ts, 200);
-    const x = (ts - t0) * pixelsPerMs + offsetX;
-    const barW = Math.max(duration * pixelsPerMs, 4);
-    const lane = getLane(evt);
-    const y = topY + lane * laneH + 4;
-    const barH = laneH - 8;
-
-    if (mx >= x && mx <= x + barW && my >= y && my <= y + barH) {
-      return evt;
-    }
-  }
-  return null;
-}
-
-function onMouseDown(e: MouseEvent): void {
-  isDragging = true;
-  dragStartX = e.clientX;
-  dragStartOffset = offsetX;
-}
-
-function onMouseMove(e: MouseEvent): void {
-  if (!canvas || !tooltip) return;
-  const rect = canvas.getBoundingClientRect();
-  const mx = e.clientX - rect.left;
-  const my = e.clientY - rect.top;
-
-  if (isDragging) {
-    offsetX = dragStartOffset + (e.clientX - dragStartX);
-    draw();
+  if (events.length === 0) {
+    wrapper.innerHTML = '<div class="vtimeline-empty">No timeline events</div>';
+    container.appendChild(wrapper);
     return;
   }
 
-  const evt = getEventAt(mx, my);
-  if (evt) {
-    canvas.style.cursor = 'pointer';
-    const time = new Date(evt.timestamp).toLocaleTimeString();
-    const content = (evt.contentText || '').slice(0, 80);
-    tooltip.innerHTML = `<div><b>${time}</b> [${evt.type || evt.role}]</div>
-      ${evt.toolName ? `<div>${escapeHtml(evt.toolName)}</div>` : ''}
-      <div style="color:var(--text-dim)">${escapeHtml(content)}</div>
-      ${evt.costUSD > 0 ? `<div style="color:var(--yellow)">$${evt.costUSD.toFixed(4)}</div>` : ''}`;
-    tooltip.style.left = `${mx + 15}px`;
-    tooltip.style.top = `${my + 15}px`;
-    tooltip.classList.add('visible');
-  } else {
-    canvas.style.cursor = 'grab';
-    tooltip.classList.remove('visible');
+  for (let i = 0; i < events.length; i++) {
+    // Render gap between entries
+    if (i > 0) {
+      const prevTs = new Date(events[i - 1].timestamp).getTime();
+      const curTs = new Date(events[i].timestamp).getTime();
+      const gapMs = curTs - prevTs;
+      if (gapMs > 0) {
+        const gapH = Math.min(40, Math.max(2, Math.log(gapMs / 100) * 6));
+        const gap = document.createElement('div');
+        gap.className = 'vtimeline-gap';
+        gap.style.height = `${gapH}px`;
+        if (gapMs > 2000) {
+          const label = document.createElement('span');
+          label.className = 'vtimeline-gap-label';
+          label.textContent = formatDurationSecs(gapMs / 1000);
+          gap.appendChild(label);
+        }
+        wrapper.appendChild(gap);
+      }
+    }
+
+    const evt = events[i];
+    const evtType = resolveType(evt);
+    const color = TYPE_COLORS[evtType] || TYPE_COLORS.system;
+    const content = evt.contentText || '';
+    const needsExpand = content.length > PREVIEW_LEN;
+
+    const entry = document.createElement('div');
+    entry.className = 'vtimeline-entry';
+    entry.style.borderLeftColor = color;
+
+    const timeEl = document.createElement('span');
+    timeEl.className = 'vtimeline-time';
+    timeEl.textContent = formatTime(evt.timestamp);
+
+    const badge = document.createElement('span');
+    badge.className = 'vtimeline-badge';
+    badge.style.background = color;
+    badge.textContent = evt.toolName || evtType;
+
+    const contentEl = document.createElement('span');
+    contentEl.className = 'vtimeline-content';
+    contentEl.textContent = needsExpand ? content.slice(0, PREVIEW_LEN) + '...' : content;
+
+    entry.appendChild(timeEl);
+    entry.appendChild(badge);
+    entry.appendChild(contentEl);
+
+    if (needsExpand) {
+      const btn = document.createElement('span');
+      btn.className = 'fe-expand';
+      btn.textContent = '+';
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const expanded = entry.classList.toggle('expanded');
+        btn.textContent = expanded ? '-' : '+';
+        contentEl.textContent = expanded
+          ? content
+          : content.slice(0, PREVIEW_LEN) + '...';
+        contentEl.appendChild(btn);
+      });
+      contentEl.appendChild(btn);
+    }
+
+    if (evt.costUSD > 0) {
+      const cost = document.createElement('span');
+      cost.className = 'vtimeline-cost';
+      cost.textContent = `$${evt.costUSD.toFixed(4)}`;
+      entry.appendChild(cost);
+    }
+
+    wrapper.appendChild(entry);
   }
-}
 
-function onMouseUp(): void {
-  isDragging = false;
-}
-
-function onWheel(e: WheelEvent): void {
-  e.preventDefault();
-  if (!canvas) return;
-  const rect = canvas.getBoundingClientRect();
-  const mx = e.clientX - rect.left;
-
-  if (e.ctrlKey || e.metaKey) {
-    // Zoom
-    const zoomFactor = e.deltaY > 0 ? 0.8 : 1.25;
-    const oldPxPerMs = pixelsPerMs;
-    pixelsPerMs *= zoomFactor;
-    pixelsPerMs = Math.max(0.001, Math.min(1, pixelsPerMs));
-    // Keep the point under cursor stable
-    offsetX = mx - (mx - offsetX) * (pixelsPerMs / oldPxPerMs);
-  } else {
-    // Pan
-    offsetX -= e.deltaY;
-  }
-  draw();
+  container.appendChild(wrapper);
 }

--- a/web/src/styles/feed.css
+++ b/web/src/styles/feed.css
@@ -412,3 +412,108 @@
   opacity: 0.75;
   border-left: 2px solid rgba(0,204,255,0.2);
 }
+
+/* Vertical Timeline */
+.vtimeline-container {
+  overflow-y: auto;
+  height: 100%;
+  padding: 8px;
+  background: var(--bg);
+}
+
+.vtimeline-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-dim);
+  font-size: 13px;
+}
+
+.vtimeline-entry {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 8px;
+  border-left: 3px solid transparent;
+  font-size: 12px;
+  line-height: 1.6;
+  transition: background 0.15s;
+}
+
+.vtimeline-entry:hover {
+  background: rgba(255,255,255,0.03);
+}
+
+.vtimeline-entry.expanded {
+  align-items: flex-start;
+}
+
+.vtimeline-entry.expanded .vtimeline-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: rgba(0,0,0,0.3);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 6px 8px;
+  margin-top: 4px;
+  font-size: 11px;
+  line-height: 1.5;
+  max-height: 300px;
+  overflow-y: auto;
+}
+
+.vtimeline-time {
+  flex: 0 0 70px;
+  color: #44445a;
+  font-size: 11px;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.vtimeline-badge {
+  flex: 0 0 80px;
+  font-size: 9px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 8px;
+  text-transform: uppercase;
+  color: #000;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vtimeline-content {
+  flex: 1;
+  min-width: 0;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.vtimeline-cost {
+  flex-shrink: 0;
+  color: var(--yellow);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  margin-left: auto;
+}
+
+.vtimeline-gap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-left: 1px dashed rgba(255,255,255,0.1);
+  margin-left: 9px;
+}
+
+.vtimeline-gap-label {
+  font-size: 9px;
+  color: #44445a;
+  font-family: var(--font-mono);
+  padding: 0 6px;
+}


### PR DESCRIPTION
## Summary
- Replaced the horizontal canvas-based Gantt chart in timeline-view.ts with a vertical, scrollable HTML/CSS timeline
- Each event displays: HH:MM:SS timestamp, color-coded type badge, expandable content preview (120 char limit), and cost
- Time gaps between events rendered proportionally with duration labels for gaps > 2 seconds
- Added .vtimeline-* CSS classes to feed.css (appended at end, no existing rules modified)

## Test plan
- [ ] Open a session timeline and verify events display vertically with correct timestamps
- [ ] Verify type badges show correct colors for user/assistant/tool_use/tool_result/hook/error
- [ ] Click expand button on long content entries to verify expand/collapse works
- [ ] Verify time gaps between events render proportionally with duration labels
- [ ] TypeScript typecheck passes
- [ ] Build passes