### PR TITLE
feat: session card progressive disclosure + cost display improvements

### DIFF
--- a/web/src/components/cost-breakdown.ts
+++ b/web/src/components/cost-breakdown.ts
@@ -3,11 +3,16 @@ import { escapeHtml } from '../utils';
 import '../styles/views.css';
 
 let popover: HTMLElement | null = null;
+let cbFilter: 'all' | 'today' = 'all';
 
 export function toggle(anchor: HTMLElement): void {
   if (popover) { popover.remove(); popover = null; return; }
 
-  const sessions = Array.from(state.sessions.values());
+  const allSessions = Array.from(state.sessions.values());
+  const todayStr = new Date().toDateString();
+  const sessions = cbFilter === 'today'
+    ? allSessions.filter(s => new Date(s.startedAt).toDateString() === todayStr)
+    : allSessions;
 
   // Aggregate by model
   const byModel = new Map<string, number>();
@@ -34,6 +39,10 @@ export function toggle(anchor: HTMLElement): void {
   // Build content
   popover.innerHTML = `
     <div class="cb-header">Cost Breakdown</div>
+    <div class="cb-filter" style="display:flex;gap:4px;padding:0 8px 6px">
+      <button class="cb-filter-btn${cbFilter === 'all' ? ' active' : ''}" data-filter="all" style="font-family:var(--font-mono);font-size:9px;padding:2px 8px;background:none;border:1px solid var(--border);color:var(--text-dim);cursor:pointer;border-radius:2px">ALL</button>
+      <button class="cb-filter-btn${cbFilter === 'today' ? ' active' : ''}" data-filter="today" style="font-family:var(--font-mono);font-size:9px;padding:2px 8px;background:none;border:1px solid var(--border);color:var(--text-dim);cursor:pointer;border-radius:2px">TODAY</button>
+    </div>
     <div class="cb-row">
       <canvas class="cb-chart" width="120" height="120" role="img" aria-label="Cost by model donut chart"></canvas>
       <div class="cb-legend"></div>
@@ -117,6 +126,24 @@ export function toggle(anchor: HTMLElement): void {
       <span style="color:var(--yellow)">$${s.totalCostUSD.toFixed(2)}</span>
     </div>`;
   }
+
+  // Filter button click handlers
+  popover.querySelectorAll<HTMLButtonElement>('.cb-filter-btn').forEach(btn => {
+    if (btn.dataset.filter === cbFilter) {
+      btn.style.borderColor = 'var(--cyan)';
+      btn.style.color = 'var(--text)';
+    }
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const newFilter = btn.dataset.filter as 'all' | 'today';
+      if (newFilter === cbFilter) return;
+      cbFilter = newFilter;
+      // Re-render: close and reopen
+      popover?.remove();
+      popover = null;
+      toggle(anchor);
+    });
+  });
 
   // Position below the anchor
   anchor.parentElement!.style.position = 'relative';

--- a/web/src/components/session-card.ts
+++ b/web/src/components/session-card.ts
@@ -4,6 +4,13 @@ import { state, update } from '../state';
 import { escapeHtml, escapeAttr, formatTokens, formatDurationSecs, timeAgo } from '../utils';
 import { getLastTool } from '../tool-tracker';
 
+function getCostTier(cost: number): string {
+  if (cost < 0.50) return 'cost-tier-low';
+  if (cost < 2) return 'cost-tier-mid';
+  if (cost < 5) return 'cost-tier-high';
+  return 'cost-tier-extreme';
+}
+
 // Track which parent sessions have their children expanded
 export const expandedParents = new Set<string>();
 // Track which parents show idle subagents (hidden by default)
@@ -49,18 +56,22 @@ export function renderExpanded(session: Session, container: HTMLElement): HTMLEl
       </div>
       <div class="session-task-desc" title="${escapeAttr(session.taskDescription)}">${escapeHtml(truncate(session.taskDescription || '', 80))}</div>
       <div class="session-stats">
-        <span class="cost">$${session.totalCostUSD.toFixed(2)}</span>
+        <span class="cost ${getCostTier(session.totalCostUSD)}">$${session.totalCostUSD.toFixed(2)}</span>
         ${session.costRate > 0 ? `<span class="cost-rate">$${session.costRate.toFixed(3)}/min</span>` : ''}
-        <span class="tok">${formatTokens(session.inputTokens + session.outputTokens + session.cacheReadTokens)} tok</span>
-        <span class="cache">${session.cacheHitPct.toFixed(0)}%</span>
-        ${session.errorCount > 0 ? `<span class="session-error-count">${session.errorCount} err</span>` : ''}
       </div>
-      <div class="session-meta">
-        <span class="model">${(session.model || '').replace('claude-', '').replace('-4-6', '')}</span>
-        <span>${timeAgo(session.lastActive)}</span>
-        <span class="duration">${formatDuration(session.startedAt, session.lastActive)}</span>
+      <div class="session-card-details">
+        <div class="session-stats">
+          <span class="tok">${formatTokens(session.inputTokens + session.outputTokens + session.cacheReadTokens)} tok</span>
+          <span class="cache">${session.cacheHitPct.toFixed(0)}%</span>
+          ${session.errorCount > 0 ? `<span class="session-error-count">${session.errorCount} err</span>` : ''}
+        </div>
+        <div class="session-meta">
+          <span class="model">${(session.model || '').replace('claude-', '').replace('-4-6', '')}</span>
+          <span>${timeAgo(session.lastActive)}</span>
+          <span class="duration">${formatDuration(session.startedAt, session.lastActive)}</span>
+        </div>
+        ${session.status === 'tool_use' ? `<div class="session-current-tool">${escapeHtml(getLastTool(session.id) || '')}</div>` : ''}
       </div>
-      ${session.status === 'tool_use' ? `<div class="session-current-tool">${escapeHtml(getLastTool(session.id) || '')}</div>` : ''}
     </div>
   `;
 
@@ -204,7 +215,7 @@ export function renderCompact(session: Session, container: HTMLElement): HTMLEle
       <span class="session-dot ${dotClass}" aria-label="${compactDotLabel}" role="img"></span>
       <span class="session-name" title="${escapeAttr(displayName)}">${escapeHtml(displayName)}</span>
       ${childCount > 0 ? `<span class="subagent-chevron" role="button" tabindex="0" aria-label="${isExpanded ? 'Collapse subagents' : 'Expand subagents'}">${isExpanded ? '▾' : '▸'} ${childCount}</span>` : ''}
-      <span class="cost">$${session.totalCostUSD.toFixed(2)}</span>
+      <span class="cost ${getCostTier(session.totalCostUSD)}">$${session.totalCostUSD.toFixed(2)}</span>
       <span class="duration">${timeAgo(session.lastActive)}</span>
       <span class="duration">${formatDuration(session.startedAt, session.lastActive)}</span>
       ${session.model ? `<span class="model">${session.model.replace('claude-', '').replace('-4-6', '')}</span>` : ''}

--- a/web/src/components/topbar.ts
+++ b/web/src/components/topbar.ts
@@ -164,7 +164,8 @@ function updateStats(): void {
   const cacheHit = totalInput > 0 ? (totalCacheRead / totalInput * 100) : 0;
 
   setVal(statActive, String(active.length));
-  setVal(statCost, `$${totalCost.toFixed(0)}`);
+  const costFmt = totalCost < 10 ? `$${totalCost.toFixed(1)}` : `$${totalCost.toFixed(0)}`;
+  setVal(statCost, costFmt);
   setVal(statWorking, String(working.length));
   setVal(statCache, cacheHit > 0 ? `${cacheHit.toFixed(0)}%` : '—');
   setVal(statRate, totalRate > 0 ? `$${totalRate.toFixed(3)}/m` : '—');

--- a/web/src/styles/sessions.css
+++ b/web/src/styles/sessions.css
@@ -380,3 +380,19 @@
   max-width: 220px;
   margin-top: 2px;
 }
+
+/* Progressive disclosure — details hidden by default, shown on hover */
+.session-card-details {
+  display: none;
+  margin-top: 2px;
+}
+.session-card:hover .session-card-details,
+.session-card.selected .session-card-details {
+  display: block;
+}
+
+/* Cost tier color grading */
+.cost-tier-low { color: var(--green) !important; }
+.cost-tier-mid { color: var(--yellow) !important; }
+.cost-tier-high { color: var(--orange) !important; }
+.cost-tier-extreme { color: var(--red) !important; }


### PR DESCRIPTION
## Summary
- **Progressive disclosure**: Session cards now hide token/cache/meta/tool details by default; revealed on hover or when selected, reducing visual clutter
- **Cost color tiers**: Cost values are color-coded (green < $0.50, yellow < $2, orange < $5, red >= $5) in both expanded and compact card views
- **Topbar cost formatting**: Shows one decimal place for totals under $10 (e.g. "$3.2" instead of "$3")
- **Cost breakdown filter**: Added TODAY/ALL toggle buttons to the cost breakdown popover to filter sessions by start date

## Test plan
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] Production build succeeds (`npm run build`)
- [ ] Verify hover reveals details on session cards
- [ ] Verify cost colors match tier thresholds
- [ ] Verify topbar cost shows decimal for small values
- [ ] Verify TODAY/ALL filter toggles in cost breakdown popover

🤖 Generated with [Claude Code](https://claude.com/claude-code)