### PR TITLE
feat: status indicator differentiation + micro-interactions

### DIFF
--- a/web/src/components/feed-panel.ts
+++ b/web/src/components/feed-panel.ts
@@ -128,7 +128,7 @@ function renderFeedPanel(): void {
         scrollLockBtn?.classList.remove('visible');
       }
     });
-    document.body.appendChild(scrollLockBtn);
+    container.appendChild(scrollLockBtn);
   }
 }
 

--- a/web/src/components/topbar.ts
+++ b/web/src/components/topbar.ts
@@ -166,6 +166,16 @@ function updateStats(): void {
   setVal(statActive, String(active.length));
   setVal(statCost, `$${totalCost.toFixed(0)}`);
   setVal(statWorking, String(working.length));
+  if (statWorking) {
+    const thinkingCount = working.filter(s => s.status === 'thinking').length;
+    const toolCount = working.filter(s => s.status === 'tool_use').length;
+    const waitingCount = active.filter(s => s.status === 'waiting').length;
+    const parts: string[] = [];
+    if (thinkingCount > 0) parts.push(`${thinkingCount} thinking`);
+    if (toolCount > 0) parts.push(`${toolCount} tool`);
+    if (waitingCount > 0) parts.push(`${waitingCount} waiting`);
+    statWorking.title = parts.length > 0 ? parts.join(', ') : 'No active work';
+  }
   setVal(statCache, cacheHit > 0 ? `${cacheHit.toFixed(0)}%` : '—');
   setVal(statRate, totalRate > 0 ? `$${totalRate.toFixed(3)}/m` : '—');
 }

--- a/web/src/styles/feed.css
+++ b/web/src/styles/feed.css
@@ -377,24 +377,25 @@
 
 /* Scroll lock button */
 .scroll-lock-btn {
-  position: fixed;
-  bottom: 38px;
-  right: 14px;
-  background: rgba(68,136,255,0.15);
-  border: 1px solid var(--cyan);
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  background: rgba(68,136,255,0.1);
+  border: none;
+  border-top: 1px solid var(--cyan);
   color: var(--cyan);
   font-family: var(--font-mono);
   font-size: 10px;
-  padding: 4px 10px;
+  padding: 4px 0;
   cursor: pointer;
   letter-spacing: 1px;
-  border-radius: 2px;
-  z-index: 50;
+  text-align: center;
+  z-index: 10;
   display: none;
 }
 
 .scroll-lock-btn:hover {
-  background: rgba(68,136,255,0.3);
+  background: rgba(68,136,255,0.2);
 }
 
 .scroll-lock-btn.visible { display: block; }

--- a/web/src/styles/sessions.css
+++ b/web/src/styles/sessions.css
@@ -157,24 +157,25 @@
 .session-dot.dot-active {
   background: var(--green);
   box-shadow: 0 0 6px var(--green);
-  animation: dotPulse 1.8s ease-in-out infinite;
+  /* No animation — solid glow indicates waiting/ready */
 }
 
 .session-dot.dot-thinking {
   background: var(--yellow);
   box-shadow: 0 0 6px var(--yellow);
-  animation: dotPulse 1.8s ease-in-out infinite;
+  animation: pulseThinking 2s ease-in-out infinite;
 }
 
 .session-dot.dot-tool {
   background: var(--cyan);
   box-shadow: 0 0 6px var(--cyan);
-  animation: dotPulse 1.8s ease-in-out infinite;
+  animation: flashTool 0.8s ease-in-out infinite;
 }
 
 .session-dot.dot-idle {
   background: var(--text-dim);
-  opacity: 0.4;
+  opacity: 0.3;
+  /* No animation — static and dim */
 }
 
 @keyframes dotPulse {
@@ -217,19 +218,20 @@
   border-radius: 2px;
   text-transform: uppercase;
   flex-shrink: 0;
-  animation: dotPulse 1.8s ease-in-out infinite;
 }
 
 .status-thinking {
   color: var(--yellow);
   border: 1px solid rgba(255,204,0,0.3);
   background: rgba(255,204,0,0.05);
+  animation: pulseThinking 2s ease-in-out infinite;
 }
 
 .status-tool_use {
   color: var(--cyan);
   border: 1px solid rgba(0,136,255,0.3);
   background: rgba(0,136,255,0.05);
+  animation: flashTool 0.8s ease-in-out infinite;
 }
 
 .status-waiting {
@@ -249,7 +251,6 @@
   color: var(--green);
   border: 1px solid rgba(0,255,136,0.3);
   background: rgba(0,255,136,0.05);
-  animation: dotPulse 1.8s ease-in-out infinite;
 }
 
 /* Task description */
@@ -379,4 +380,16 @@
   white-space: nowrap;
   max-width: 220px;
   margin-top: 2px;
+}
+
+/* Differentiated status animations */
+@keyframes pulseThinking {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+@keyframes flashTool {
+  0%, 70% { opacity: 1; }
+  85% { opacity: 0.3; }
+  100% { opacity: 1; }
 }


### PR DESCRIPTION
## Summary
- Add differentiated keyframe animations per session status type: pulseThinking (slow 2s pulse for thinking), flashTool (fast 0.8s flash for tool_use), solid glow for active/waiting, static dim for idle
- Add WORKING stat tooltip in topbar showing breakdown of thinking/tool/waiting counts
- Reposition scroll-lock button from fixed document.body overlay to sticky flush bar inside the feed panel container

## Test plan
- [ ] Verify thinking sessions show slow pulsing animation on dot and badge
- [ ] Verify tool_use sessions show fast flash animation on dot and badge
- [ ] Verify active/waiting sessions show solid glow with no animation
- [ ] Verify idle sessions are static and dim
- [ ] Hover over WORKING stat in topbar to see status breakdown tooltip
- [ ] Scroll up in feed panel to see sticky scroll-lock bar at bottom of feed area
- [ ] Click scroll-lock bar to resume auto-scroll