### PR TITLE
feat: DAG workflow view replaces force-directed graph

### DIFF
--- a/web/src/components/graph-view.ts
+++ b/web/src/components/graph-view.ts
@@ -5,38 +5,63 @@ import { state, subscribe, update } from '../state';
 import { escapeHtml } from '../utils';
 import '../styles/views.css';
 
-interface GraphNode {
+function sessionDisplayName(sess: Session): string {
+  return sess.sessionName || sess.projectName || sess.id.slice(0, 8);
+}
+
+interface DagNode {
   id: string;
   x: number;
   y: number;
-  vx: number;
-  vy: number;
-  radius: number;
+  width: number;
+  height: number;
   color: string;
   label: string;
+  costLabel: string;
   session: Session;
+  isActive: boolean;
 }
 
-interface GraphEdge {
+interface DagEdge {
   source: string;
   target: string;
 }
 
+// Canvas state
 let container: HTMLElement | null = null;
 let canvas: HTMLCanvasElement | null = null;
 let tooltip: HTMLElement | null = null;
 let ctx: CanvasRenderingContext2D | null = null;
-let nodes: GraphNode[] = [];
-let edges: GraphEdge[] = [];
-let nodeMap = new Map<string, GraphNode>();
-let animFrame: number | null = null;
-let dragging: GraphNode | null = null;
-let hovering: GraphNode | null = null;
+let nodes: DagNode[] = [];
+let edges: DagEdge[] = [];
+let nodeMap = new Map<string, DagNode>();
 let prevNodeIds = '';
-let settledFrames = 0;
 let graphMode: 'graph' | 'sequence' = 'graph';
-const SETTLE_THRESHOLD = 0.1;
-const SETTLE_FRAMES = 30;
+
+// Viewport transform (pan & zoom)
+let panX = 0;
+let panY = 0;
+let zoom = 1;
+let isPanning = false;
+let panStartX = 0;
+let panStartY = 0;
+let panStartPanX = 0;
+let panStartPanY = 0;
+
+// Hover state
+let hoveredNode: DagNode | null = null;
+
+// Animation
+let animFrame: number | null = null;
+
+// Layout constants
+const NODE_HEIGHT = 32;
+const MIN_NODE_WIDTH = 60;
+const MAX_NODE_WIDTH = 200;
+const ROW_GAP = 12;
+const PIXELS_PER_SECOND = 3;
+const LEFT_PADDING = 40;
+const TOP_PADDING = 40;
 
 export function render(mount: HTMLElement): void {
   container = mount;
@@ -53,7 +78,8 @@ function onStateChange(_state: AppState, changed: Set<string>): void {
   }
   if (changed.has('sessions') && state.view === 'graph') {
     if (graphMode === 'graph') {
-      rebuildNodes();
+      rebuildDag();
+      drawFrame();
     } else {
       show(); // re-render sequence list
     }
@@ -97,10 +123,18 @@ function show(): void {
     canvas.addEventListener('mousedown', onMouseDown);
     canvas.addEventListener('mousemove', onMouseMove);
     canvas.addEventListener('mouseup', onMouseUp);
+    canvas.addEventListener('mouseleave', onMouseLeave);
     canvas.addEventListener('click', onClick);
+    canvas.addEventListener('wheel', onWheel, { passive: false });
 
-    rebuildNodes();
-    startAnimation();
+    // Reset viewport
+    panX = 0;
+    panY = 0;
+    zoom = 1;
+    prevNodeIds = '';
+
+    rebuildDag();
+    drawFrame();
   } else {
     container.appendChild(wrapper);
     renderSequence(wrapper);
@@ -132,7 +166,7 @@ function renderSequence(wrapper: HTMLElement): void {
     entry.style.paddingLeft = `${12 + depth * 24}px`;
 
     const time = sess.startedAt ? new Date(sess.startedAt).toLocaleTimeString() : '';
-    const name = sess.sessionName || sess.projectName || sess.id.slice(0, 8);
+    const name = sessionDisplayName(sess);
     const cost = `$${sess.totalCostUSD.toFixed(2)}`;
     const statusClass = sess.isActive
       ? (sess.status === 'thinking' ? 'thinking' : sess.status === 'tool_use' ? 'tool-use' : 'active')
@@ -171,62 +205,59 @@ function resizeCanvas(): void {
   canvas.width = container.clientWidth;
   canvas.height = container.clientHeight;
   ctx = canvas.getContext('2d');
+  drawFrame();
 }
 
-function rebuildNodes(): void {
-  if (!canvas) return;
+function getVisibleSessions(): Session[] {
   const now = Date.now();
-  const threshold = 120_000; // 120 seconds
+  const threshold = 120_000;
 
-  const visibleSessions: Session[] = [];
+  const visible: Session[] = [];
   for (const sess of state.sessions.values()) {
     const lastActive = new Date(sess.lastActive).getTime();
     if (sess.isActive || (now - lastActive) < threshold) {
-      visibleSessions.push(sess);
+      visible.push(sess);
     }
   }
 
   // Include parents of visible nodes
-  const visibleIds = new Set(visibleSessions.map(s => s.id));
-  for (const sess of visibleSessions) {
+  const visibleIds = new Set(visible.map(s => s.id));
+  for (const sess of visible) {
     if (sess.parentId && !visibleIds.has(sess.parentId)) {
       const parent = state.sessions.get(sess.parentId);
       if (parent) {
-        visibleSessions.push(parent);
+        visible.push(parent);
         visibleIds.add(parent.id);
       }
     }
   }
 
+  return visible;
+}
+
+function statusColor(sess: Session): string {
+  if (!sess.isActive) return '#44445a';
+  if (sess.status === 'thinking') return '#d29922';
+  if (sess.status === 'tool_use') return '#58a6ff';
+  return '#3fb950';
+}
+
+function rebuildDag(): void {
+  const visibleSessions = getVisibleSessions();
+  const visibleIds = new Set(visibleSessions.map(s => s.id));
+
   const nodeIds = [...visibleIds].sort().join(',');
   if (nodeIds === prevNodeIds) return;
   prevNodeIds = nodeIds;
 
-  const oldNodes = new Map(nodes.map(n => [n.id, n]));
-  const cx = (canvas?.width ?? 800) / 2;
-  const cy = (canvas?.height ?? 600) / 2;
+  if (visibleSessions.length === 0) {
+    nodes = [];
+    edges = [];
+    nodeMap = new Map();
+    return;
+  }
 
-  nodes = visibleSessions.map(sess => {
-    const old = oldNodes.get(sess.id);
-    const radius = Math.min(30, Math.max(8, Math.log(sess.totalCostUSD + 1) * 5 + 8));
-    const color = sess.isActive
-      ? (sess.status === 'thinking' ? '#ffcc00' : sess.status === 'tool_use' ? '#4488ff' : '#00ff88')
-      : '#44445a';
-    const label = (sess.sessionName || sess.projectName || sess.id).substring(0, 16);
-
-    return {
-      id: sess.id,
-      x: old?.x ?? cx + (Math.random() - 0.5) * 200,
-      y: old?.y ?? cy + (Math.random() - 0.5) * 200,
-      vx: old?.vx ?? 0,
-      vy: old?.vy ?? 0,
-      radius, color, label, session: sess,
-    };
-  });
-
-  // Rebuild cached nodeMap
-  nodeMap = new Map(nodes.map(n => [n.id, n]));
-
+  // Build edges
   edges = [];
   for (const sess of visibleSessions) {
     if (sess.parentId && visibleIds.has(sess.parentId)) {
@@ -234,153 +265,275 @@ function rebuildNodes(): void {
     }
   }
 
-  // Reset idle detection and restart animation
-  settledFrames = 0;
-  if (animFrame === null && state.view === 'graph') {
-    startAnimation();
-  }
-}
+  // Find the global time range
+  const timestamps = visibleSessions.map(s => new Date(s.startedAt).getTime());
+  const minTime = Math.min(...timestamps);
 
-function simulate(): void {
-  if (!canvas) return;
-  const w = canvas.width;
-  const h = canvas.height;
-
-  // Repulsion
-  for (let i = 0; i < nodes.length; i++) {
-    for (let j = i + 1; j < nodes.length; j++) {
-      const a = nodes[i], b = nodes[j];
-      const dx = b.x - a.x, dy = b.y - a.y;
-      const dist = Math.max(1, Math.sqrt(dx * dx + dy * dy));
-      const force = 2000 / (dist * dist);
-      const fx = (dx / dist) * force, fy = (dy / dist) * force;
-      a.vx -= fx; a.vy -= fy;
-      b.vx += fx; b.vy += fy;
+  // Build children map
+  const childrenMap = new Map<string, Session[]>();
+  for (const sess of visibleSessions) {
+    if (sess.parentId && visibleIds.has(sess.parentId)) {
+      const children = childrenMap.get(sess.parentId) || [];
+      children.push(sess);
+      childrenMap.set(sess.parentId, children);
     }
   }
 
-  // Attraction along edges (use cached nodeMap)
-  for (const edge of edges) {
-    const a = nodeMap.get(edge.source), b = nodeMap.get(edge.target);
-    if (!a || !b) continue;
-    const dx = b.x - a.x, dy = b.y - a.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
-    const force = (dist - 100) * 0.01;
-    const fx = (dx / dist) * force, fy = (dy / dist) * force;
-    a.vx += fx; a.vy += fy;
-    b.vx -= fx; b.vy -= fy;
-  }
+  // Find roots (no parentId or parent not in visible set)
+  const roots = visibleSessions
+    .filter(s => !s.parentId || !visibleIds.has(s.parentId))
+    .sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
 
-  // Center gravity + damping + bounds
-  const cx = w / 2, cy = h / 2;
-  for (const n of nodes) {
-    n.vx += (cx - n.x) * 0.001;
-    n.vy += (cy - n.y) * 0.001;
-    n.vx *= 0.9;
-    n.vy *= 0.9;
-    if (n !== dragging) {
-      n.x += n.vx;
-      n.y += n.vy;
+  // Layout: assign X from timestamp, Y from row assignment
+  // Use a simple greedy row packing algorithm
+  nodes = [];
+
+  // Track which rows are occupied at each time range (for stacking siblings)
+  const rowEndTimes: number[] = []; // rowEndTimes[row] = the rightmost X end for that row
+
+  function assignRow(startX: number, width: number): number {
+    // Find the first row where this node fits
+    for (let r = 0; r < rowEndTimes.length; r++) {
+      if (startX >= rowEndTimes[r] + ROW_GAP) {
+        rowEndTimes[r] = startX + width;
+        return r;
+      }
     }
-    n.x = Math.max(n.radius, Math.min(w - n.radius, n.x));
-    n.y = Math.max(n.radius, Math.min(h - n.radius, n.y));
+    // New row
+    const r = rowEndTimes.length;
+    rowEndTimes.push(startX + width);
+    return r;
   }
 
-  // Idle detection: check if all velocities are below threshold
-  const allSettled = nodes.every(n => Math.abs(n.vx) < SETTLE_THRESHOLD && Math.abs(n.vy) < SETTLE_THRESHOLD);
-  if (allSettled) {
-    settledFrames++;
-  } else {
-    settledFrames = 0;
+  function layoutSession(sess: Session): void {
+    const startMs = new Date(sess.startedAt).getTime();
+    const endMs = new Date(sess.lastActive).getTime();
+    const durationSec = Math.max(0, (endMs - startMs) / 1000);
+
+    const x = LEFT_PADDING + ((startMs - minTime) / 1000) * PIXELS_PER_SECOND;
+    const rawWidth = durationSec * PIXELS_PER_SECOND;
+    const width = Math.max(MIN_NODE_WIDTH, Math.min(MAX_NODE_WIDTH, rawWidth));
+
+    const row = assignRow(x, width);
+
+    const y = TOP_PADDING + row * (NODE_HEIGHT + ROW_GAP);
+    const name = sessionDisplayName(sess);
+    const label = name.substring(0, Math.floor(width / 6)); // ~6px per char at 10px monospace
+    const costLabel = `$${sess.totalCostUSD.toFixed(2)}`;
+
+    const node: DagNode = {
+      id: sess.id,
+      x, y, width, height: NODE_HEIGHT,
+      color: statusColor(sess),
+      label,
+      costLabel,
+      session: sess,
+      isActive: sess.isActive,
+    };
+    nodes.push(node);
+
+    // Layout children
+    const children = childrenMap.get(sess.id);
+    if (children) {
+      children
+        .sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime())
+        .forEach(child => layoutSession(child));
+    }
   }
+
+  for (const root of roots) {
+    layoutSession(root);
+  }
+
+  // Rebuild cached nodeMap
+  nodeMap = new Map(nodes.map(n => [n.id, n]));
 }
 
-function draw(): void {
+function drawFrame(): void {
   if (!ctx || !canvas) return;
   ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-  // Edges (use cached nodeMap)
-  ctx.strokeStyle = 'rgba(100,100,140,0.3)';
-  ctx.lineWidth = 1;
-  for (const edge of edges) {
-    const a = nodeMap.get(edge.source), b = nodeMap.get(edge.target);
-    if (!a || !b) continue;
-    ctx.beginPath();
-    ctx.moveTo(a.x, a.y);
-    ctx.lineTo(b.x, b.y);
-    ctx.stroke();
-  }
+  ctx.save();
+  ctx.translate(panX, panY);
+  ctx.scale(zoom, zoom);
 
-  // Nodes
-  for (const n of nodes) {
-    ctx.globalAlpha = n === hovering ? 1.0 : 0.7;
-    ctx.fillStyle = n.color;
+  drawEdges();
+  drawNodes();
+
+  ctx.restore();
+}
+
+function drawEdges(): void {
+  if (!ctx) return;
+
+  ctx.lineWidth = 1.5 / zoom;
+
+  for (const edge of edges) {
+    const src = nodeMap.get(edge.source);
+    const tgt = nodeMap.get(edge.target);
+    if (!src || !tgt) continue;
+
+    const x1 = src.x + src.width;
+    const y1 = src.y + src.height / 2;
+    const x2 = tgt.x;
+    const y2 = tgt.y + tgt.height / 2;
+
+    // Bezier curve
+    const cpOffset = Math.min(Math.abs(x2 - x1) * 0.4, 60);
+    ctx.strokeStyle = 'rgba(100,100,140,0.4)';
     ctx.beginPath();
-    ctx.arc(n.x, n.y, n.radius + (n === hovering ? 2 : 0), 0, Math.PI * 2);
+    ctx.moveTo(x1, y1);
+    ctx.bezierCurveTo(x1 + cpOffset, y1, x2 - cpOffset, y2, x2, y2);
+    ctx.stroke();
+
+    // Arrowhead: compute tangent angle at the target end of the bezier
+    const arrowSize = 5 / zoom;
+    const angle = Math.atan2(y2 - y1, cpOffset);
+
+    ctx.fillStyle = 'rgba(100,100,140,0.4)';
+    ctx.beginPath();
+    ctx.moveTo(x2, y2);
+    ctx.lineTo(x2 - arrowSize * Math.cos(angle - 0.4), y2 - arrowSize * Math.sin(angle - 0.4));
+    ctx.lineTo(x2 - arrowSize * Math.cos(angle + 0.4), y2 - arrowSize * Math.sin(angle + 0.4));
+    ctx.closePath();
     ctx.fill();
-    if (n === hovering) {
-      ctx.strokeStyle = '#fff';
-      ctx.lineWidth = 2;
-      ctx.stroke();
+  }
+}
+
+function drawNodes(): void {
+  if (!ctx) return;
+
+  for (const n of nodes) {
+    const isHovered = n === hoveredNode;
+
+    // Glow for active nodes
+    if (n.isActive) {
+      ctx.shadowColor = n.color;
+      ctx.shadowBlur = isHovered ? 12 : 6;
     }
+
+    // Rounded rectangle
+    const r = 6;
+    ctx.fillStyle = n.color;
+    ctx.globalAlpha = isHovered ? 1.0 : 0.8;
+    ctx.beginPath();
+    ctx.moveTo(n.x + r, n.y);
+    ctx.lineTo(n.x + n.width - r, n.y);
+    ctx.arcTo(n.x + n.width, n.y, n.x + n.width, n.y + r, r);
+    ctx.lineTo(n.x + n.width, n.y + n.height - r);
+    ctx.arcTo(n.x + n.width, n.y + n.height, n.x + n.width - r, n.y + n.height, r);
+    ctx.lineTo(n.x + r, n.y + n.height);
+    ctx.arcTo(n.x, n.y + n.height, n.x, n.y + n.height - r, r);
+    ctx.lineTo(n.x, n.y + r);
+    ctx.arcTo(n.x, n.y, n.x + r, n.y, r);
+    ctx.closePath();
+    ctx.fill();
+
+    // Reset shadow
+    ctx.shadowColor = 'transparent';
+    ctx.shadowBlur = 0;
     ctx.globalAlpha = 1.0;
 
-    // Label
-    ctx.fillStyle = '#aaa';
-    ctx.font = '10px monospace';
-    ctx.textAlign = 'center';
-    ctx.fillText(n.label, n.x, n.y + n.radius + 14);
+    // Hover border
+    if (isHovered) {
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 1.5 / zoom;
+      ctx.stroke();
+    }
 
-    // Cost
-    if (n.session.totalCostUSD > 0.01) {
-      ctx.fillStyle = '#888';
-      ctx.font = '8px monospace';
-      ctx.fillText(`$${n.session.totalCostUSD.toFixed(2)}`, n.x, n.y + n.radius + 24);
+    // Label text inside node
+    ctx.fillStyle = '#fff';
+    ctx.font = '10px monospace';
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'middle';
+
+    const textX = n.x + 6;
+    const textY = n.y + n.height / 2;
+    const maxTextWidth = n.width - 12;
+
+    // Combine label + cost if there's room
+    const combined = n.label + ' ' + n.costLabel;
+    if (ctx.measureText(combined).width <= maxTextWidth) {
+      ctx.fillText(n.label, textX, textY);
+      // Cost in dimmer color
+      const labelWidth = ctx.measureText(n.label + ' ').width;
+      ctx.fillStyle = 'rgba(255,255,255,0.6)';
+      ctx.fillText(n.costLabel, textX + labelWidth, textY);
+    } else {
+      // Just the label, truncated
+      ctx.fillText(n.label, textX, textY, maxTextWidth);
     }
   }
 }
 
-function getNodeAt(x: number, y: number): GraphNode | null {
-  for (const n of nodes) {
-    const dx = x - n.x, dy = y - n.y;
-    if (dx * dx + dy * dy < (n.radius + 4) * (n.radius + 4)) return n;
+// --- Hit testing ---
+
+function screenToWorld(sx: number, sy: number): { x: number; y: number } {
+  return {
+    x: (sx - panX) / zoom,
+    y: (sy - panY) / zoom,
+  };
+}
+
+function getNodeAt(sx: number, sy: number): DagNode | null {
+  const { x, y } = screenToWorld(sx, sy);
+  // Iterate in reverse so top-drawn nodes are picked first
+  for (let i = nodes.length - 1; i >= 0; i--) {
+    const n = nodes[i];
+    if (x >= n.x && x <= n.x + n.width && y >= n.y && y <= n.y + n.height) {
+      return n;
+    }
   }
   return null;
 }
 
+// --- Event handlers ---
+
 function onMouseDown(e: MouseEvent): void {
-  const rect = canvas!.getBoundingClientRect();
-  dragging = getNodeAt(e.clientX - rect.left, e.clientY - rect.top);
-  if (dragging) {
-    // Restart animation on drag
-    settledFrames = 0;
-    if (animFrame === null) {
-      startAnimation();
-    }
+  if (!canvas) return;
+  const rect = canvas.getBoundingClientRect();
+  const mx = e.clientX - rect.left;
+  const my = e.clientY - rect.top;
+
+  const node = getNodeAt(mx, my);
+  if (!node) {
+    // Start panning
+    isPanning = true;
+    panStartX = e.clientX;
+    panStartY = e.clientY;
+    panStartPanX = panX;
+    panStartPanY = panY;
+    canvas.style.cursor = 'grabbing';
   }
 }
 
 function onMouseMove(e: MouseEvent): void {
   if (!canvas || !tooltip) return;
   const rect = canvas.getBoundingClientRect();
-  const mx = e.clientX - rect.left, my = e.clientY - rect.top;
+  const mx = e.clientX - rect.left;
+  const my = e.clientY - rect.top;
 
-  if (dragging) {
-    dragging.x = mx;
-    dragging.y = my;
-    dragging.vx = 0;
-    dragging.vy = 0;
+  if (isPanning) {
+    panX = panStartPanX + (e.clientX - panStartX);
+    panY = panStartPanY + (e.clientY - panStartY);
+    drawFrame();
     return;
   }
 
   const node = getNodeAt(mx, my);
-  hovering = node;
-  canvas.style.cursor = node ? 'pointer' : 'default';
+  if (node !== hoveredNode) {
+    hoveredNode = node;
+    drawFrame();
+  }
+
+  canvas.style.cursor = node ? 'pointer' : 'grab';
 
   if (node) {
-    tooltip.innerHTML = `<div><b>${escapeHtml(node.label)}</b></div>
-      <div>$${node.session.totalCostUSD.toFixed(2)} · ${node.session.messageCount} msgs</div>
-      <div>${node.session.status} · ${node.session.model || '?'}</div>`;
+    const sess = node.session;
+    const name = sessionDisplayName(sess);
+    tooltip.innerHTML = `<div><b>${escapeHtml(name)}</b></div>
+      <div>$${sess.totalCostUSD.toFixed(2)} · ${sess.messageCount} msgs</div>
+      <div>${sess.status} · ${sess.model || '?'}</div>`;
     tooltip.style.left = `${mx + 15}px`;
     tooltip.style.top = `${my + 15}px`;
     tooltip.classList.add('visible');
@@ -390,7 +543,15 @@ function onMouseMove(e: MouseEvent): void {
 }
 
 function onMouseUp(): void {
-  dragging = null;
+  isPanning = false;
+  if (canvas) canvas.style.cursor = 'grab';
+}
+
+function onMouseLeave(): void {
+  isPanning = false;
+  hoveredNode = null;
+  if (tooltip) tooltip.classList.remove('visible');
+  drawFrame();
 }
 
 function onClick(e: MouseEvent): void {
@@ -402,18 +563,29 @@ function onClick(e: MouseEvent): void {
   }
 }
 
-function startAnimation(): void {
-  function loop() {
-    simulate();
-    draw();
-    // Stop if settled for enough frames
-    if (settledFrames >= SETTLE_FRAMES) {
-      animFrame = null;
-      return;
-    }
-    animFrame = requestAnimationFrame(loop);
+function onWheel(e: WheelEvent): void {
+  e.preventDefault();
+  if (!canvas) return;
+
+  if (e.ctrlKey || e.metaKey) {
+    // Zoom
+    const rect = canvas.getBoundingClientRect();
+    const mx = e.clientX - rect.left;
+    const my = e.clientY - rect.top;
+
+    const zoomFactor = e.deltaY > 0 ? 0.9 : 1.1;
+    const newZoom = Math.max(0.2, Math.min(5, zoom * zoomFactor));
+
+    // Zoom toward cursor
+    panX = mx - (mx - panX) * (newZoom / zoom);
+    panY = my - (my - panY) * (newZoom / zoom);
+    zoom = newZoom;
+  } else {
+    // Horizontal scroll
+    panX -= e.deltaX || e.deltaY;
   }
-  animFrame = requestAnimationFrame(loop);
+
+  drawFrame();
 }
 
 function stopAnimation(): void {

--- a/web/src/styles/views.css
+++ b/web/src/styles/views.css
@@ -11,7 +11,10 @@
   display: block;
   width: 100%;
   height: 100%;
+  cursor: grab;
 }
+
+.graph-container canvas:active { cursor: grabbing; }
 
 .graph-tooltip {
   position: absolute;


### PR DESCRIPTION
## Summary
- Replace the force-directed physics simulation in graph view with a deterministic horizontal DAG pipeline layout
- X-axis maps to time (startedAt), Y-axis uses greedy row packing for parallel sessions
- Nodes are rounded rectangles sized by duration, colored by status (thinking/tool_use/active/idle)
- Bezier curve edges with arrowheads connect parent to child sessions
- Pan (mouse drag) and zoom (ctrl+wheel) interactions; horizontal scroll via wheel
- Sequence mode preserved as accessible fallback with existing toggle

## Test plan
- [ ] Open graph view with multiple active sessions and verify horizontal DAG layout
- [ ] Verify node colors match status: yellow=thinking, cyan=tool_use, green=active, gray=idle
- [ ] Click a node and confirm it navigates to list view with that session selected
- [ ] Hover nodes and verify tooltip shows name, cost, messages, model, status
- [ ] Test pan (drag empty space) and zoom (ctrl+wheel) interactions
- [ ] Test horizontal scroll (wheel without ctrl)
- [ ] Toggle to sequence mode and back to verify both modes work
- [ ] Verify parent-child edges render as bezier curves with arrowheads

🤖 Generated with [Claude Code](https://claude.com/claude-code)