### PR TITLE
fix: release pipeline duplicate tag + QA test artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,18 +65,19 @@ jobs:
     needs: [build-and-test, lint]
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created == 'true' && 'true' || steps.create-release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name || steps.create-release.outputs.tag_name }}
+      release_created: ${{ steps.create-release.outputs.release_created }}
+      tag_name: ${{ steps.create-release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: go
+          skip-github-release: true
 
       # Auto-merge the release PR so releases ship without manual intervention.
       # Only when release-please created a PR but didn't already create the release.
       - name: Auto-merge release PR
-        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release.outputs.release_created != 'true' }}
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -86,19 +87,25 @@ jobs:
       # github.token merges don't trigger downstream workflows, so the normal
       # second-pass (where release-please detects its own merged PR and creates
       # the GitHub release) never fires. We create the tag and release directly
-      # in this same run instead.
+      # in this same run instead — but only if they don't already exist.
       - name: Create release after merge
         id: create-release
-        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release.outputs.release_created != 'true' }}
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           PR_NUMBER=${{ fromJSON(steps.release.outputs.prs)[0].number }}
-          # PR objects don't have tagName; extract version from the PR title
-          # which release-please formats as "chore(main): release X.Y.Z"
           PR_TITLE="${{ fromJSON(steps.release.outputs.prs)[0].title }}"
           VERSION=$(echo "${PR_TITLE}" | grep -oP '\d+\.\d+\.\d+')
           TAG_NAME="v${VERSION}"
+
+          # Skip if release already exists (idempotent)
+          if gh release view "${TAG_NAME}" --repo ${{ github.repository }} &>/dev/null; then
+            echo "Release ${TAG_NAME} already exists, skipping"
+            echo "release_created=true" >> $GITHUB_OUTPUT
+            echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
 
           # Wait for merge to propagate
           sleep 3
@@ -106,12 +113,12 @@ jobs:
           # Get the merge commit SHA from the PR
           MERGE_SHA=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER} --jq '.merge_commit_sha')
 
-          # Create the tag pointing at the merge commit
+          # Create the tag (skip if it already exists)
           gh api repos/${{ github.repository }}/git/refs \
             -f ref="refs/tags/${TAG_NAME}" \
-            -f sha="${MERGE_SHA}"
+            -f sha="${MERGE_SHA}" || true
 
-          # Extract release notes from the PR body (strip the bot preamble)
+          # Extract release notes from the PR body
           gh pr view ${PR_NUMBER} --repo ${{ github.repository }} --json body --jq '.body' > /tmp/release-notes.md
 
           # Create the GitHub release


### PR DESCRIPTION
## Summary
- Fix release pipeline `Duplicate release tag` error by adding `skip-github-release: true` to release-please and making our custom release step idempotent
- Remove phantom `t` keyboard shortcut from help overlay (found during QA)
- Add QA test plan and issues tracker docs

## Changes
- `.github/workflows/ci.yml`: release-please only manages PRs now; custom step checks for existing releases before creating
- `web/src/components/help-overlay.ts`: remove `t` → "Table view" shortcut that had no handler
- `docs/frontend-qa-test-plan.md`: 242-case manual QA plan
- `docs/qa-issues.md`: issue tracker (4 open low-severity items)

## Test plan
- [x] CI passes on PR (build-and-test + lint green)
- [ ] Merge to main → release pipeline should pass without duplicate tag error

🤖 Generated with [Claude Code](https://claude.com/claude-code)