### PR TITLE
fix: homebrew formula binary name and makefile ldflags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,10 @@ jobs:
           cd dist
           for bin in claude-monitor-*; do
             chmod +x "$bin"
-            tar czf "${bin}.tar.gz" "$bin"
+            # Rename to plain "claude-monitor" so Homebrew's bin.install works
+            cp "$bin" claude-monitor
+            tar czf "${bin}.tar.gz" claude-monitor
+            rm claude-monitor
           done
           sha256sum *.tar.gz > checksums.txt
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 .PHONY: build dev clean test lint web migrate migrate-status migrate-rollback migrate-create
 
+# Version from release-please manifest (fallback to "dev")
+VERSION ?= $(shell cat .release-please-manifest.json 2>/dev/null | grep -o '"[^"]*"$$' | tr -d '"' || echo "dev")
+LDFLAGS := -s -w -X main.version=$(VERSION)
+
 # Build frontend then Go binary
 build: web
-	go build -o claude-monitor ./cmd/claude-monitor
+	go build -ldflags="$(LDFLAGS)" -o claude-monitor ./cmd/claude-monitor
 
 # Build and run with live reload (frontend dev server proxies to Go backend)
 dev:
 	@echo "Starting Go backend on :7700..."
-	@go build -o /tmp/claude-monitor-dev ./cmd/claude-monitor && \
+	@go build -ldflags="$(LDFLAGS)" -o /tmp/claude-monitor-dev ./cmd/claude-monitor && \
 		/tmp/claude-monitor-dev -port 7700 & \
 		GO_PID=$$!; \
 		trap "kill $$GO_PID 2>/dev/null; exit" INT TERM EXIT; \


### PR DESCRIPTION
## Summary
- **Binary name mismatch**: CI tarball step now renames platform-specific binaries (e.g. `claude-monitor-darwin-arm64`) to plain `claude-monitor` inside each tarball, so the formula's `bin.install "claude-monitor"` works correctly
- **Makefile ldflags**: Added `-ldflags "-s -w -X main.version=..."` to `make build` and `make dev` targets, pulling the version from `.release-please-manifest.json` so local builds report the correct version instead of `"dev"`
- **Version sync**: Formula version (`3.1.1`) already matches the release-please manifest on main, so no formula change needed — the CI automation fixed this after the issue was filed

Closes #179

## Test plan
- [ ] `make build && ./claude-monitor --version` reports `3.1.1` (not `dev`)
- [ ] CI release job: verify each tarball contains a file named `claude-monitor` (not `claude-monitor-<platform>`)
- [ ] `brew install --build-from-source Formula/claude-monitor.rb` succeeds on macOS (both arm64 and amd64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)