### PR TITLE
fix: help overlay escape key, focus trap, and close button

### DIFF
--- a/web/src/components/help-overlay.ts
+++ b/web/src/components/help-overlay.ts
@@ -2,13 +2,23 @@
 import '../styles/views.css';
 
 let overlay: HTMLElement | null = null;
+let previousFocus: HTMLElement | null = null;
+
+function close(): void {
+  if (!overlay) return;
+  overlay.remove();
+  overlay = null;
+  previousFocus?.focus();
+  previousFocus = null;
+}
 
 export function toggle(): void {
   if (overlay) {
-    overlay.remove();
-    overlay = null;
+    close();
     return;
   }
+
+  previousFocus = document.activeElement as HTMLElement | null;
 
   overlay = document.createElement('div');
   overlay.className = 'help-overlay';
@@ -17,7 +27,10 @@ export function toggle(): void {
   overlay.setAttribute('aria-label', 'Keyboard shortcuts');
   overlay.innerHTML = `
     <div class="help-content">
-      <h3>Keyboard Shortcuts</h3>
+      <div class="help-header">
+        <h3>Keyboard Shortcuts</h3>
+        <button class="help-close-btn" aria-label="Close" title="Close">&#x2715;</button>
+      </div>
       <div class="help-row"><span>Focus search</span><kbd>/</kbd></div>
       <div class="help-row"><span>Clear / deselect</span><kbd>Esc</kbd></div>
       <div class="help-row"><span>Navigate sessions</span><kbd>↑↓</kbd></div>
@@ -32,18 +45,38 @@ export function toggle(): void {
     </div>
   `;
 
+  const closeBtn = overlay.querySelector('.help-close-btn') as HTMLElement;
+  closeBtn.addEventListener('click', close);
+
   overlay.addEventListener('click', (e) => {
-    if (e.target === overlay) {
-      overlay!.remove();
-      overlay = null;
-    }
+    if (e.target === overlay) close();
   });
+
   overlay.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') {
-      overlay!.remove();
-      overlay = null;
+      e.stopPropagation();
+      close();
+      return;
+    }
+
+    // Focus trap: keep Tab within the overlay
+    if (e.key === 'Tab') {
+      const focusable = overlay!.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     }
   });
 
   document.body.appendChild(overlay);
+  closeBtn.focus();
 }

--- a/web/src/styles/views.css
+++ b/web/src/styles/views.css
@@ -210,6 +210,37 @@
   max-width: 400px;
 }
 
+.help-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.help-header h3 {
+  margin: 0;
+}
+
+.help-close-btn {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  cursor: pointer;
+  font-size: 16px;
+  font-family: var(--font-mono);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.help-close-btn:hover {
+  color: var(--text);
+}
+
+.help-close-btn:focus-visible {
+  outline: 1px solid var(--cyan);
+  outline-offset: 2px;
+}
+
 .help-content h3 {
   color: var(--cyan);
   font-size: 13px;


### PR DESCRIPTION
## Summary
- **Escape key now closes the overlay** -- the close button receives initial focus when the overlay opens, so keyboard events are properly captured
- **Focus trap added** -- Tab/Shift+Tab cycles within the overlay instead of leaking into background content
- **Close button (X) added** in the top-right corner of the overlay for mouse users
- **Focus restoration** -- when the overlay closes, focus returns to the previously focused element

Closes #167

## Test plan
- [ ] Open help overlay with `?` key, verify close button appears and has focus
- [ ] Press Escape to close -- overlay should dismiss
- [ ] Open overlay, press Tab repeatedly -- focus should cycle within overlay (close button only in this case)
- [ ] Open overlay, click the X button -- overlay should close
- [ ] Open overlay, click the backdrop -- overlay should close
- [ ] After closing, verify focus returns to the element that was focused before opening

🤖 Generated with [Claude Code](https://claude.com/claude-code)