### PR TITLE
fix: prevent hub broadcast from blocking pipeline, add graceful shutdown

### DIFF
--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -576,7 +576,10 @@ Examples:
 		// 3. Flush pipeline — saves batched events and session data.
 		pipe.Stop()
 
-		// 4. Shutdown HTTP server (closes WebSocket connections).
+		// 4. Send WebSocket close frames and stop the hub goroutine.
+		h.GracefulStop()
+
+		// 5. Shutdown HTTP server.
 		shutCtx, shutCancel := context.WithTimeout(context.Background(), shutdownTimeout)
 		defer shutCancel()
 		if err := srv.Shutdown(shutCtx); err != nil {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -61,6 +61,8 @@ type Hub struct {
 	register   chan *Client
 	unregister chan *Client
 	done       chan struct{}
+	graceful   chan struct{} // signals Run to perform graceful shutdown
+	stopped    chan struct{} // closed when Run returns
 }
 
 // NewHub creates a Hub ready to be started with Run.
@@ -71,15 +73,31 @@ func NewHub() *Hub {
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
 		done:       make(chan struct{}),
+		graceful:   make(chan struct{}),
+		stopped:    make(chan struct{}),
 	}
 }
 
 // Run processes register/unregister/broadcast events. Call in a goroutine.
-// It returns when Stop is called.
+// It returns when Stop or GracefulStop is called.
 func (h *Hub) Run() {
+	defer close(h.stopped)
 	for {
 		select {
 		case <-h.done:
+			return
+
+		case <-h.graceful:
+			// Perform graceful shutdown inside the Run goroutine where
+			// h.clients access is safe (no concurrent modification).
+			// Closing each client's send channel causes writePump to send a
+			// WebSocket close frame and exit, which is also safe from the
+			// gorilla/websocket concurrency perspective since only writePump
+			// writes to the connection.
+			for client := range h.clients {
+				close(client.send)
+				delete(h.clients, client)
+			}
 			return
 
 		case client := <-h.register:
@@ -121,17 +139,16 @@ func (h *Hub) Broadcast(msg []byte) {
 	}
 }
 
-// GracefulStop sends a WebSocket close frame to every connected client, then
-// stops the hub. This gives browsers the opportunity to handle the closure
-// cleanly instead of seeing an abnormal TCP disconnect.
+// GracefulStop closes every connected client's send channel, which triggers
+// each writePump to send a WebSocket close frame (CloseGoingAway) and exit.
+// This gives browsers the opportunity to handle the closure cleanly instead
+// of seeing an abnormal TCP disconnect.
+//
+// The client iteration happens inside the Run goroutine to avoid a race
+// condition on h.clients. GracefulStop blocks until Run has finished.
 func (h *Hub) GracefulStop() {
-	for client := range h.clients {
-		client.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
-		client.conn.WriteMessage(websocket.CloseMessage,
-			websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutting down"))
-		client.conn.Close()
-	}
-	h.Stop()
+	close(h.graceful)
+	<-h.stopped
 }
 
 // ServeWs upgrades an HTTP connection to WebSocket and registers it with hub.
@@ -191,8 +208,9 @@ func (c *Client) writePump() {
 		case msg, ok := <-c.send:
 			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
 			if !ok {
-				// Hub closed the channel.
-				c.conn.WriteMessage(websocket.CloseMessage, []byte{})
+				// Hub closed the channel — send close frame and exit.
+				c.conn.WriteMessage(websocket.CloseMessage,
+					websocket.FormatCloseMessage(websocket.CloseGoingAway, ""))
 				return
 			}
 			if err := c.conn.WriteMessage(websocket.TextMessage, msg); err != nil {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -111,8 +111,27 @@ func (h *Hub) Stop() {
 }
 
 // Broadcast enqueues msg for delivery to all connected clients.
+// If the broadcast channel is full the message is dropped to avoid blocking
+// the caller (typically the event pipeline goroutine).
 func (h *Hub) Broadcast(msg []byte) {
-	h.broadcast <- msg
+	select {
+	case h.broadcast <- msg:
+	default:
+		log.Printf("hub: broadcast channel full, dropping message (%d bytes)", len(msg))
+	}
+}
+
+// GracefulStop sends a WebSocket close frame to every connected client, then
+// stops the hub. This gives browsers the opportunity to handle the closure
+// cleanly instead of seeing an abnormal TCP disconnect.
+func (h *Hub) GracefulStop() {
+	for client := range h.clients {
+		client.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		client.conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseGoingAway, "server shutting down"))
+		client.conn.Close()
+	}
+	h.Stop()
 }
 
 // ServeWs upgrades an HTTP connection to WebSocket and registers it with hub.

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -2,9 +2,14 @@ package hub
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 func TestNewHub_CreatesHubWithNoClients(t *testing.T) {
@@ -252,5 +257,97 @@ func TestHub_MultipleSequentialBroadcastsReceivedInOrder(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Fatalf("timeout waiting for message %d", i)
 		}
+	}
+}
+
+func TestHub_GracefulStop_NoRace(t *testing.T) {
+	t.Parallel()
+	h := NewHub()
+	go h.Run()
+
+	// Start an HTTP test server that upgrades connections to WebSocket.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ServeWs(h, w, r)
+	}))
+	defer srv.Close()
+
+	// Connect several WebSocket clients.
+	const numClients = 5
+	conns := make([]*websocket.Conn, numClients)
+	for i := 0; i < numClients; i++ {
+		wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+		c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		conns[i] = c
+		defer conns[i].Close()
+	}
+
+	// Give the hub a moment to process all registrations.
+	time.Sleep(50 * time.Millisecond)
+
+	// GracefulStop should complete without racing on h.clients.
+	done := make(chan struct{})
+	go func() {
+		h.GracefulStop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// GracefulStop returned — success.
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout: GracefulStop did not return")
+	}
+}
+
+func TestHub_GracefulStopWithConcurrentActivity(t *testing.T) {
+	t.Parallel()
+	h := NewHub()
+	go h.Run()
+
+	// Start an HTTP test server.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ServeWs(h, w, r)
+	}))
+	defer srv.Close()
+
+	// Connect a WebSocket client.
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/ws"
+	c, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	// Concurrently broadcast while calling GracefulStop.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 100; i++ {
+			h.Broadcast([]byte(fmt.Sprintf("msg-%d", i)))
+		}
+	}()
+
+	// Give broadcasts a head start, then graceful stop.
+	time.Sleep(5 * time.Millisecond)
+	h.GracefulStop()
+	wg.Wait()
+}
+
+func TestHub_StopClosesStoppedChannel(t *testing.T) {
+	t.Parallel()
+	h := NewHub()
+	go h.Run()
+
+	h.Stop()
+
+	select {
+	case <-h.stopped:
+		// stopped channel was closed — correct.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout: stopped channel not closed after Stop()")
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #171: Hub broadcast channel can block the event pipeline indefinitely.

Three related fixes:

- **Non-blocking broadcast**: `Broadcast()` now uses `select` with `default` to drop messages when the 256-slot channel is full, logging a warning instead of blocking the event pipeline goroutine indefinitely.
- **Graceful WebSocket close**: New `GracefulStop()` method sends `CloseGoingAway` frames to all connected clients before stopping the hub, so browsers see a clean disconnect instead of an abnormal TCP closure.
- **Hub shutdown in main.go**: Added `h.GracefulStop()` call in the shutdown sequence (step 4, before HTTP server shutdown) so the hub goroutine is properly stopped during SIGINT/SIGTERM handling.

## Files changed
- `internal/hub/hub.go` — non-blocking `Broadcast()`, new `GracefulStop()` method
- `cmd/claude-monitor/main.go` — call `h.GracefulStop()` in shutdown sequence

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All 8 existing hub tests pass (`go test ./internal/hub/ -v`)
- [ ] Manual: start monitor, connect browser, send SIGINT — browser should see clean close frame
- [ ] Manual: flood broadcast channel (256+ messages) — pipeline should not stall, warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)