### PR TITLE
fix: docker non-root user, .dockerignore, swagger redirect, favicon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+node_modules
+dist
+nohup.out
+*.exe
+.env
+.claude
+.playwright-mcp
+audit
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,15 @@ RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o claude-monitor ./cmd/c
 # Stage 3: minimal runtime
 FROM alpine:3.19
 RUN apk add --no-cache ca-certificates
+RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 COPY --from=builder /app/claude-monitor .
+RUN chown -R app:app /app
+USER app
 EXPOSE 7700
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD wget -q --spider http://localhost:7700/health || exit 1
 # Mount your .claude directories via volumes:
-# docker run -v ~/.claude:/home/node/.claude:ro -p 7700:7700 claude-monitor
+# docker run -v ~/.claude:/home/app/.claude:ro -p 7700:7700 claude-monitor
 ENTRYPOINT ["./claude-monitor"]
 CMD ["--port", "7700"]

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -546,10 +546,18 @@ Examples:
 	mux.HandleFunc("GET /health", handleHealth(historyDB, fw))
 	mux.HandleFunc("GET /api/version", handleVersion())
 
+	// Favicon — return 204 No Content to suppress browser console errors.
+	mux.HandleFunc("GET /favicon.ico", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
 	// Swagger UI (opt-in via --swagger flag).
 	if *swaggerEnabled {
 		mux.HandleFunc("GET /swagger/openapi.yaml", handleSwaggerYAML())
 		mux.HandleFunc("GET /swagger", handleSwaggerUI())
+		mux.HandleFunc("GET /swagger/", func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/swagger", http.StatusMovedPermanently)
+		})
 		log.Println("swagger UI enabled at /swagger")
 	}
 


### PR DESCRIPTION
## Summary
- **Non-root user**: Added `app` user/group in Dockerfile runtime stage so container no longer runs as root
- **`.dockerignore`**: Created to exclude `.git`, `node_modules`, `dist`, `nohup.out`, `*.exe`, `.env`, `.claude`, `.playwright-mcp`, `audit`, `docs` from build context
- **Swagger trailing slash**: `GET /swagger/` now redirects 301 to `/swagger` instead of returning 404
- **Favicon**: `GET /favicon.ico` returns 204 No Content to suppress browser console errors

## Test plan
- [ ] `docker build .` succeeds and context is smaller (no `.git` etc.)
- [ ] `docker run` container runs as non-root user (`whoami` returns `app`)
- [ ] `/swagger/` redirects to `/swagger` when `--swagger` flag is used
- [ ] `/favicon.ico` returns 204 with no console errors

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)