### PR TITLE
ci: fix lint enforcement, add security scanning, add ESLint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   build-and-test:
@@ -29,6 +28,9 @@ jobs:
 
       - name: Frontend type check
         run: cd web && npx tsc --noEmit
+
+      - name: Frontend lint
+        run: cd web && npm run lint
 
       - name: Build
         run: go build ./...
@@ -64,10 +66,18 @@ jobs:
         uses: golangci/golangci-lint-action@v6
         with:
           version: latest
-        continue-on-error: true
+        continue-on-error: false
+
+      - name: Security scan (govulncheck)
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
 
   # Create or update the release PR on pushes to main
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.ref == 'refs/heads/main'
     needs: [build-and-test, lint]
     runs-on: ubuntu-latest
@@ -83,6 +93,8 @@ jobs:
 
   # Build and upload binaries when release-please creates a release
   build-binaries:
+    permissions:
+      contents: write
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,3 +5,7 @@ linters:
     - errcheck
     - govet
     - staticcheck
+    - gosimple
+    - ineffassign
+    - unused
+    - gocritic


### PR DESCRIPTION
## Summary
- **golangci-lint enforcement**: Changed `continue-on-error` from `true` to `false` so lint failures block CI
- **Security scanning**: Added `govulncheck ./...` step after lint in the `lint` job
- **Frontend ESLint**: Added `npm run lint` step in `build-and-test` job after the existing `tsc --noEmit` type check
- **Least-privilege permissions**: Moved `contents: write` / `pull-requests: write` from global scope to only the `release-please` and `build-binaries` jobs that need them; global scope is now `contents: read`
- **Expanded linters**: Added `gosimple`, `ineffassign`, `unused`, `gocritic` to `.golangci.yml`

Closes #173

## Test plan
- [ ] CI passes on this PR (lint, type check, ESLint, govulncheck all run and block on failure)
- [ ] Verify release-please job still has write permissions to create release PRs
- [ ] Verify build-binaries job still has write permissions to upload assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)