### PR TITLE
fix: UX improvements — notification debounce, sidebar toggle, search close

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,17 +268,24 @@ Full OpenAPI spec at [`api/openapi.yaml`](api/openapi.yaml). Enable Swagger UI w
 
 | Endpoint | Description |
 |----------|-------------|
-| `GET /health` | Health check |
+| `GET /health` | Health check (includes `droppedEvents` counter) |
 | `GET /api/version` | Server version |
-| `GET /api/sessions` | All sessions with aggregated stats |
-| `GET /api/sessions/grouped` | Sessions grouped by time bucket |
-| `GET /api/projects` | Distinct project names with counts |
-| `GET /api/search?q=&limit=` | Cross-session full-text search |
-| `GET /api/history?limit=&offset=` | Historical sessions from SQLite |
-| `GET /api/sessions/{id}/recent` | Last 50 messages for a session |
-| `GET /api/sessions/{id}/replay` | Replay manifest (all events) |
-| `GET /api/sessions/{id}/replay/stream` | SSE replay stream |
-| `POST /api/sessions/{id}/stop` | Stop Docker container |
+| `GET /api/sessions` | List sessions (supports `?active=true`, `?group=activity`, pagination) |
+| `GET /api/sessions/{id}` | Single session lookup (live store, then DB fallback) |
+| `GET /api/sessions/{id}/events` | Session events (supports `?pinned`, `?errors`, `?last=N`, pagination) |
+| `GET /api/sessions/{id}/replay` | Replay manifest (all events, up to 10k) |
+| `POST /api/sessions/{id}/stop` | Stop Docker container for a session |
+| `GET /api/stats` | Aggregated stats with `?window=` (all, today, week, month) |
+| `GET /api/stats/trends` | Trend data with `?window=` (24h, 7d, 30d) and optional `?repo=` |
+| `GET /api/repos` | Repository list with total costs |
+| `GET /api/repos/{id}/stats` | Per-repo aggregate statistics |
+| `GET /api/repos/{id}/sessions` | Paginated sessions for a repo |
+| `GET /api/search?q=&limit=` | FTS5 full-text search across sessions |
+| `GET /api/search/full?q=&limit=` | Full-content substring search (slower, searches complete text) |
+| `GET /api/settings` | Get all user-configurable settings |
+| `PUT /api/settings/{key}` | Update a single setting by key |
+| `GET /api/storage` | Database storage info (size, event counts) |
+| `DELETE /api/cache/repos` | Clear repo resolver cache |
 | `GET /ws` | WebSocket (live events) |
 | `GET /swagger` | Swagger UI (requires `--swagger`) |
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: >
     REST and WebSocket API for claude-monitor — a daemon that watches Claude Code
     JSONL session files and broadcasts activity over WebSocket.
-  version: "2.0.0"
+  version: "3.1.1"
 
 servers:
   - url: http://localhost:7700
@@ -46,7 +46,7 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [ok, db]
+                required: [ok, db, droppedEvents]
                 properties:
                   ok:
                     type: boolean
@@ -54,13 +54,18 @@ paths:
                   db:
                     type: string
                     example: "ok"
+                  droppedEvents:
+                    type: integer
+                    format: int64
+                    description: Total number of file-watcher events dropped due to a full channel.
+                    example: 0
         "503":
           description: Database unhealthy
           content:
             application/json:
               schema:
                 type: object
-                required: [ok, db]
+                required: [ok, db, droppedEvents]
                 properties:
                   ok:
                     type: boolean
@@ -68,6 +73,11 @@ paths:
                   db:
                     type: string
                     example: "database is locked"
+                  droppedEvents:
+                    type: integer
+                    format: int64
+                    description: Total number of file-watcher events dropped due to a full channel.
+                    example: 0
 
   /api/version:
     get:
@@ -83,7 +93,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/VersionResponse"
               example:
-                version: "v2.0.0"
+                version: "v3.1.1"
 
   /api/sessions:
     get:
@@ -664,7 +674,7 @@ components:
         version:
           type: string
           description: Build version string (set via ldflags at compile time).
-          example: "v2.0.0"
+          example: "v3.1.1"
 
     Session:
       type: object
@@ -1038,6 +1048,31 @@ components:
         entrypoint:
           type: string
           description: Session entrypoint (cli, vscode, etc.). Omitted when empty.
+        toolUseIds:
+          type: string
+          description: >
+            JSON-encoded array of all tool_use block IDs in this event (for
+            batched tool calls). Omitted when empty.
+          example: "[\"toolu_01AbcDef\",\"toolu_02GhiJkl\"]"
+        cwd:
+          type: string
+          description: Working directory extracted from the event. Omitted when empty.
+          example: "/root/my-project"
+        gitBranch:
+          type: string
+          description: Git branch name extracted from the event. Omitted when empty.
+          example: "feature/auth-refactor"
+        isSidechain:
+          type: boolean
+          description: True when this event is from a sidechain (background) conversation.
+        agentName:
+          type: string
+          description: Agent name within a team. Omitted when empty.
+          example: "code-reviewer"
+        teamName:
+          type: string
+          description: Team name for team agents. Omitted when empty.
+          example: "engineering"
 
     ReplayManifest:
       type: object
@@ -1155,6 +1190,7 @@ components:
         - costRate
         - costByModel
         - costByRepo
+        - droppedEvents
       properties:
         totalCost:
           type: number
@@ -1219,6 +1255,11 @@ components:
           example:
             a1b2c3d4: 80.00
             e5f6g7h8: 62.37
+        droppedEvents:
+          type: integer
+          format: int64
+          description: Total number of file-watcher events dropped due to a full channel.
+          example: 0
 
     TrendResult:
       type: object

--- a/web/src/components/budget-popover.ts
+++ b/web/src/components/budget-popover.ts
@@ -20,6 +20,7 @@ let refreshTimer: ReturnType<typeof setInterval> | null = null;
 let banner: HTMLElement | null = null;
 let costStatEl: HTMLElement | null = null;
 let rateStatEl: HTMLElement | null = null;
+let budgetNotificationSent = false;
 
 export function dismiss(): void {
   closePanel();
@@ -238,12 +239,14 @@ function renderPanelContent(): void {
     const val = parseFloat(input.value);
     if (!isNaN(val) && val > 0) {
       localStorage.setItem('budget', String(val));
+      budgetNotificationSent = false;
       update({ budgetThreshold: val, budgetDismissed: false });
       renderPanelContent();
     }
   });
   settingsEl.querySelector('.clear-btn')!.addEventListener('click', () => {
     localStorage.removeItem('budget');
+    budgetNotificationSent = false;
     update({ budgetThreshold: null, budgetDismissed: false });
     renderPanelContent();
   });
@@ -397,17 +400,22 @@ function checkBudget(): void {
         <button style="background:none;border:none;color:var(--red);cursor:pointer;font-family:var(--font-mono)" aria-label="Dismiss budget warning">✕</button>`;
       banner.querySelector('button')!.addEventListener('click', () => {
         update({ budgetDismissed: true });
+        budgetNotificationSent = false;
       });
-      notify(
-        'budget',
-        'Budget Exceeded',
-        `Total spend $${total.toFixed(0)} exceeds $${state.budgetThreshold}`,
-      );
+      if (!budgetNotificationSent) {
+        budgetNotificationSent = true;
+        notify(
+          'budget',
+          'Budget Exceeded',
+          `Total spend $${total.toFixed(0)} exceeds $${state.budgetThreshold}`,
+        );
+      }
     } else {
       banner.className = 'budget-banner hidden';
     }
   } else {
     costStatEl.classList.remove('over-budget');
     banner.className = 'budget-banner hidden';
+    budgetNotificationSent = false;
   }
 }

--- a/web/src/components/history-view.ts
+++ b/web/src/components/history-view.ts
@@ -76,9 +76,19 @@ export function render(mount: HTMLElement): void {
 
 let historyRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
+function showLoading(): void {
+  if (!container) return;
+  container.innerHTML = '';
+  const wrapper = document.createElement('div');
+  wrapper.className = 'view-overlay';
+  wrapper.innerHTML = '<div style="text-align:center;padding:48px;color:var(--text-dim);font-family:var(--font-mono);font-size:12px;letter-spacing:1px">LOADING HISTORY...</div>';
+  container.appendChild(wrapper);
+}
+
 function onStateChange(_state: AppState, changed: Set<string>): void {
   if (changed.has('view')) {
     if (state.view === 'history') {
+      showLoading();
       loadData();
     } else {
       // Clear any pending refresh timer when leaving history view

--- a/web/src/components/search.ts
+++ b/web/src/components/search.ts
@@ -15,6 +15,16 @@ export function render(searchBoxEl: HTMLElement): void {
   dropdown.setAttribute('aria-label', 'Search results');
   searchBoxEl.appendChild(dropdown);
 
+  // Close dropdown on outside click
+  document.addEventListener('click', (e) => {
+    if (!dropdown || dropdown.classList.contains('search-dropdown-hidden')) return;
+    if (!searchBoxEl.contains(e.target as Node)) {
+      const searchInput = document.querySelector<HTMLInputElement>('[data-search]');
+      if (searchInput) searchInput.value = '';
+      update({ searchQuery: '', searchOpen: false, searchResults: [] });
+    }
+  });
+
   subscribe(onStateChange);
 }
 

--- a/web/src/components/session-list.ts
+++ b/web/src/components/session-list.ts
@@ -1,7 +1,7 @@
 // web/src/components/session-list.ts
 import type { Session } from '../types';
 import type { AppState } from '../state';
-import { state, subscribe } from '../state';
+import { state, subscribe, update } from '../state';
 import { renderCompact } from './session-card';
 import { isSessionActive } from '../utils';
 import '../styles/sessions.css';
@@ -47,6 +47,20 @@ export function render(container: HTMLElement): void {
   listEl = document.createElement('div');
   listEl.style.cssText = 'flex:1; overflow-y:auto;';
   el.appendChild(listEl);
+
+  // Sidebar collapse toggle
+  const toggleBtn = document.createElement('button');
+  toggleBtn.className = 'sidebar-toggle';
+  toggleBtn.textContent = '◀';
+  toggleBtn.setAttribute('aria-label', 'Collapse sidebar');
+  toggleBtn.addEventListener('click', () => {
+    const collapsed = !state.sidebarCollapsed;
+    update({ sidebarCollapsed: collapsed });
+    el!.classList.toggle('collapsed', collapsed);
+    toggleBtn.textContent = collapsed ? '▶' : '◀';
+    toggleBtn.setAttribute('aria-label', collapsed ? 'Expand sidebar' : 'Collapse sidebar');
+  });
+  el.appendChild(toggleBtn);
 
   container.appendChild(el);
 

--- a/web/src/notifications.ts
+++ b/web/src/notifications.ts
@@ -28,6 +28,7 @@ export function getSettings(): NotifSettings {
 export async function notify(type: 'budget' | 'error', title: string, body: string): Promise<void> {
   if (type === 'budget' && !settings.budget) return;
   if (type === 'error' && !settings.error) return;
+  if (typeof Notification === 'undefined') return;
   if (Notification.permission === 'default') {
     const result = await Notification.requestPermission();
     if (result !== 'granted') return;


### PR DESCRIPTION
## Summary
- **Budget notification debounce**: `checkBudget()` was calling `notify('budget', ...)` on every stats update (~5s) while budget was exceeded. Added a `budgetNotificationSent` flag that ensures the notification fires only once per exceedance period, resetting on dismiss, budget threshold change, or when spend drops back under budget.
- **Notification API feature detection**: Added `typeof Notification !== 'undefined'` guard before accessing `Notification.permission`, preventing throws in environments without the Web Notifications API.
- **Sidebar toggle**: Wired up the existing `sidebarCollapsed` state and `.sessions-panel.collapsed` / `.sidebar-toggle` CSS with a collapse/expand button at the bottom of the session list panel.
- **Search dropdown close-on-click**: Added a `document.addEventListener('click')` handler that closes the search dropdown and clears the input when clicking outside the search box.
- **History loading state**: Shows a "LOADING HISTORY..." indicator while data is being fetched, replacing the blank screen.

Closes #181

## Test plan
- [ ] Set a budget below current spend, verify notification fires once (not repeatedly every 5s)
- [ ] Dismiss the budget warning, verify notification does not re-fire until budget is changed or reset
- [ ] Open in an environment without Notification API (e.g., some embedded webviews) — verify no JS errors
- [ ] Click the sidebar toggle button (at bottom of session list) — verify sidebar collapses/expands
- [ ] Open search dropdown with results, click outside — verify it closes
- [ ] Switch to History view — verify "LOADING HISTORY..." appears before data renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)