### PR TITLE
fix: timeline view HiDPI hit-testing, close button, and listener cleanup

### DIFF
--- a/web/src/components/feed-panel.ts
+++ b/web/src/components/feed-panel.ts
@@ -8,7 +8,6 @@ import { renderFeedEntry, detectType } from './render-message';
 import { escapeHtml, sessionDisplayName } from '../utils';
 import { setLastTool } from '../tool-tracker';
 import { notify } from '../notifications';
-import { open as openTimeline } from './timeline-view';
 import '../styles/feed.css';
 
 let container: HTMLElement | null = null;
@@ -208,12 +207,12 @@ function updateHeader(): void {
     });
     const timelineBtn = headerEl.querySelector('.timeline-btn');
     timelineBtn?.addEventListener('click', () => {
-      if (state.selectedSessionId) openTimeline(state.selectedSessionId);
+      if (state.selectedSessionId) update({ view: 'timeline' });
     });
     timelineBtn?.addEventListener('keydown', (e) => {
       if ((e as KeyboardEvent).key === 'Enter' || (e as KeyboardEvent).key === ' ') {
         e.preventDefault();
-        if (state.selectedSessionId) openTimeline(state.selectedSessionId);
+        if (state.selectedSessionId) update({ view: 'timeline' });
       }
     });
   } else {

--- a/web/src/components/timeline-view.ts
+++ b/web/src/components/timeline-view.ts
@@ -1,4 +1,6 @@
 // web/src/components/timeline-view.ts
+import type { AppState } from '../state';
+import { state, subscribe, update } from '../state';
 import { escapeHtml, formatDurationSecs } from '../utils';
 import '../styles/views.css';
 
@@ -39,9 +41,26 @@ let dragStartOffset = 0;
 
 export function render(mount: HTMLElement): void {
   container = mount;
+  subscribe(onStateChange);
 }
 
-export async function open(sid: string): Promise<void> {
+function onStateChange(_state: AppState, changed: Set<string>): void {
+  if (changed.has('view')) {
+    if (state.view === 'timeline') {
+      const sid = state.selectedSessionId;
+      if (sid) {
+        open(sid);
+      } else {
+        // No session selected — go back to list
+        update({ view: 'list' });
+      }
+    } else {
+      close();
+    }
+  }
+}
+
+async function open(sid: string): Promise<void> {
   await loadEvents(sid);
   show();
 }
@@ -55,11 +74,12 @@ export function close(): void {
     canvas.removeEventListener('mouseleave', onMouseUp);
     canvas.removeEventListener('wheel', onWheel);
   }
+  window.removeEventListener('resize', resizeCanvas);
+  document.removeEventListener('keydown', onKeyDown);
   canvas = null;
   ctx = null;
   tooltip = null;
   events = [];
-  window.removeEventListener('resize', resizeCanvas);
 }
 
 async function loadEvents(sid: string): Promise<void> {
@@ -79,6 +99,16 @@ function show(): void {
   const wrapper = document.createElement('div');
   wrapper.className = 'timeline-container';
 
+  // Close / back button
+  const closeBtn = document.createElement('button');
+  closeBtn.className = 'timeline-close-btn';
+  closeBtn.textContent = '\u2190 BACK';
+  closeBtn.title = 'Close timeline (Escape)';
+  closeBtn.addEventListener('click', () => {
+    update({ view: 'list' });
+  });
+  wrapper.appendChild(closeBtn);
+
   canvas = document.createElement('canvas');
   wrapper.appendChild(canvas);
 
@@ -97,6 +127,10 @@ function show(): void {
   canvas.addEventListener('mouseleave', onMouseUp);
   canvas.addEventListener('wheel', onWheel, { passive: false });
 
+  // Escape key to close
+  document.removeEventListener('keydown', onKeyDown);
+  document.addEventListener('keydown', onKeyDown);
+
   // Reset view
   offsetX = 0;
   if (events.length > 1) {
@@ -109,6 +143,14 @@ function show(): void {
   }
 
   draw();
+}
+
+function onKeyDown(e: KeyboardEvent): void {
+  if (e.key === 'Escape' && state.view === 'timeline') {
+    e.preventDefault();
+    e.stopPropagation();
+    update({ view: 'list' });
+  }
 }
 
 function resizeCanvas(): void {
@@ -270,8 +312,12 @@ function draw(): void {
 }
 
 function getEventAt(mx: number, my: number): TimelineEvent | null {
-  if (events.length < 2 || !canvas) return null;
-  const h = canvas.height;
+  if (events.length < 2 || !container) return null;
+  // Use logical (CSS) pixel dimensions to match mouse coordinates from
+  // getBoundingClientRect(). canvas.height is DPR-scaled and must NOT be
+  // used here — it would cause hit-testing to target the wrong lane on
+  // HiDPI displays.
+  const h = container.clientHeight;
   const laneH = (h - 30) / 3;
   const topY = 30;
   const t0 = new Date(events[0].timestamp).getTime();

--- a/web/src/hash.ts
+++ b/web/src/hash.ts
@@ -37,7 +37,7 @@ function restoreFromHash(): void {
   const session = params.get('session');
   if (session) changes.selectedSessionId = session;
   const view = params.get('view');
-  if (view && ['list', 'graph', 'history'].includes(view)) {
+  if (view && ['list', 'graph', 'history', 'analytics', 'timeline'].includes(view)) {
     changes.view = view;
   }
   if (Object.keys(changes).length > 0) {

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -5,7 +5,7 @@ export interface AppState {
   sessions: Map<string, Session>;
   grouped: GroupedSessions | null;
   selectedSessionId: string | null;
-  view: 'list' | 'graph' | 'history' | 'analytics';
+  view: 'list' | 'graph' | 'history' | 'analytics' | 'timeline';
   repoFilter: string | null;
   searchQuery: string;
   searchResults: Event[];

--- a/web/src/styles/views.css
+++ b/web/src/styles/views.css
@@ -1,5 +1,61 @@
 /* web/src/styles/views.css */
 
+/* Timeline view */
+.timeline-container {
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+.timeline-container canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+.timeline-container canvas:active {
+  cursor: grabbing;
+}
+
+.timeline-tooltip {
+  position: absolute;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 10px;
+  font-size: 11px;
+  color: var(--text);
+  pointer-events: none;
+  z-index: 50;
+  white-space: nowrap;
+  display: none;
+}
+
+.timeline-tooltip.visible {
+  display: block;
+}
+
+.timeline-close-btn {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  z-index: 10;
+  background: var(--bg-card, #1a1a2e);
+  border: 1px solid var(--border, #333);
+  color: var(--cyan, #00d4ff);
+  font-family: var(--font-mono, monospace);
+  font-size: 10px;
+  padding: 3px 10px;
+  cursor: pointer;
+  border-radius: 4px;
+  letter-spacing: 0.5px;
+}
+
+.timeline-close-btn:hover {
+  background: var(--bg-hover, #2a2a3e);
+}
+
 /* Graph view */
 .graph-container {
   width: 100%;


### PR DESCRIPTION
## Summary
- **HiDPI hit-testing bug**: `getEventAt()` used `canvas.height` (DPR-scaled physical pixels) for lane calculations while mouse coordinates from `getBoundingClientRect()` are in logical pixels. Fixed to use `container.clientHeight`, matching how `draw()` already works.
- **No close button**: Added a BACK button (top-right) and Escape key handler to return to the feed view.
- **Event listener leak**: Integrated timeline into the view state system (`state.view = 'timeline'`) so `close()` is called automatically when navigating to any other view. Previously `close()` was exported but never called.

## Changes
- `web/src/components/timeline-view.ts` — Core fixes: HiDPI hit-testing, close button, Escape key, state-driven lifecycle via `subscribe()`
- `web/src/components/feed-panel.ts` — Use `update({ view: 'timeline' })` instead of calling `openTimeline()` directly
- `web/src/state.ts` — Add `'timeline'` to the view union type
- `web/src/hash.ts` — Recognize `'timeline'` as a valid view for hash-based routing
- `web/src/styles/views.css` — Add timeline container, tooltip, and close button styles

## Test plan
- [ ] Open timeline on a 1x display and verify click targets match visual lanes
- [ ] Open timeline on a 2x HiDPI display and verify click targets match visual lanes
- [ ] Click the BACK button in timeline view and verify it returns to feed
- [ ] Press Escape in timeline view and verify it returns to feed
- [ ] Navigate to `#view=timeline` with a session selected and verify it opens correctly
- [ ] Navigate to `#view=list` while in timeline and verify it switches back
- [ ] Open timeline, navigate away, and verify no resize/mouse listeners remain on the window/canvas
- [ ] Open DevTools and confirm no console errors during open/close cycles

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)