### PR TITLE
fix: add ARIA attributes, canvas accessibility, color contrast, mobile panel

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
         <div class="feed-empty">Select a session to view its feed</div>
       </main>
     </div>
-    <footer id="statusbar">
+    <footer id="statusbar" role="status" aria-label="Application status">
       <div class="sb-item">
         <span class="sb-dot connected" id="conn-dot"></span>
         <span id="conn-indicator" class="connected">CONNECTED</span>

--- a/web/src/colors.ts
+++ b/web/src/colors.ts
@@ -5,7 +5,7 @@ export const COLORS = {
   bgCard: '#161b22',
   bgDeep: '#0f0f1a',
   text: '#c9d1d9',
-  textDim: '#8b949e',
+  textDim: '#9da5ad',
   green: '#3fb950',
   yellow: '#d29922',
   red: '#f85149',

--- a/web/src/components/analytics-cards.ts
+++ b/web/src/components/analytics-cards.ts
@@ -301,6 +301,9 @@ export function renderCards(
 
     const header = document.createElement('div');
     header.className = 'analytics-card-header';
+    header.setAttribute('role', 'button');
+    header.setAttribute('tabindex', '0');
+    header.setAttribute('aria-expanded', String(expanded));
     header.innerHTML = `
       <span class="analytics-card-toggle">${expanded ? '▼' : '▶'}</span>
       <span class="analytics-card-title">${def.title}</span>
@@ -331,6 +334,7 @@ export function renderCards(
         // Collapse
         body.style.display = 'none';
         header.querySelector('.analytics-card-toggle')!.textContent = '▶';
+        header.setAttribute('aria-expanded', 'false');
         const existing = charts.get(def.id);
         if (existing) {
           existing.destroy();
@@ -341,9 +345,16 @@ export function renderCards(
         // Expand
         body.style.display = '';
         header.querySelector('.analytics-card-toggle')!.textContent = '▼';
+        header.setAttribute('aria-expanded', 'true');
         const chart = def.render(canvas, data);
         charts.set(def.id, chart);
         onToggle(def.id, true);
+      }
+    });
+    header.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        header.click();
       }
     });
   }

--- a/web/src/components/feed-panel.ts
+++ b/web/src/components/feed-panel.ts
@@ -124,9 +124,12 @@ function renderFeedPanel(): void {
   filterBar.className = 'feed-type-filters';
   for (const type of FILTER_TYPES) {
     const btn = document.createElement('button');
-    btn.className = `feed-filter-btn ${type === 'all' ? 'all-btn' : ''} ${type === 'all' || state.feedTypeFilters[type] ? 'active' : ''}`;
+    const isActive = type === 'all' || state.feedTypeFilters[type];
+    btn.className = `feed-filter-btn ${type === 'all' ? 'all-btn' : ''} ${isActive ? 'active' : ''}`;
     btn.textContent = type.toUpperCase();
     btn.dataset.type = type;
+    btn.setAttribute('aria-pressed', String(!!isActive));
+    btn.setAttribute('aria-label', `Filter by ${type.replace('_', ' ')} messages`);
     btn.addEventListener('click', (e) => handleFilterClick(type, e as MouseEvent));
     filterBar!.appendChild(btn);
   }
@@ -255,7 +258,9 @@ function updateFilterButtons(): void {
   filterBar.querySelectorAll<HTMLButtonElement>('.feed-filter-btn').forEach((btn) => {
     const t = btn.dataset.type!;
     if (t === 'all') return;
-    btn.classList.toggle('active', state.feedTypeFilters[t] ?? true);
+    const isActive = state.feedTypeFilters[t] ?? true;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
   });
 }
 

--- a/web/src/components/graph-view.ts
+++ b/web/src/components/graph-view.ts
@@ -89,6 +89,9 @@ function show(): void {
 
   if (graphMode === 'graph') {
     canvas = document.createElement('canvas');
+    canvas.setAttribute('role', 'img');
+    canvas.setAttribute('aria-label', 'Session dependency graph — nodes represent active sessions, edges show parent-child relationships');
+    canvas.textContent = 'Session dependency graph visualization';
     wrapper.appendChild(canvas);
 
     tooltip = document.createElement('div');

--- a/web/src/components/search.ts
+++ b/web/src/components/search.ts
@@ -11,6 +11,8 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 export function render(searchBoxEl: HTMLElement): void {
   dropdown = document.createElement('div');
   dropdown.className = 'search-dropdown search-dropdown-hidden';
+  dropdown.setAttribute('role', 'listbox');
+  dropdown.setAttribute('aria-label', 'Search results');
   searchBoxEl.appendChild(dropdown);
 
   subscribe(onStateChange);
@@ -93,6 +95,7 @@ function renderResults(): void {
     for (const result of visibleResults) {
       const el = document.createElement('div');
       el.className = 'search-result';
+      el.setAttribute('role', 'option');
       el.innerHTML = `
         <div class="search-result-header">
           <span class="search-result-session">${escapeHtml(group.name)}</span>

--- a/web/src/components/session-list.ts
+++ b/web/src/components/session-list.ts
@@ -24,15 +24,19 @@ export function render(container: HTMLElement): void {
   const filterBar = document.createElement('div');
   filterBar.className = 'session-filter-bar';
   filterBar.innerHTML = `
-    <button data-filter="active">ACTIVE (<span id="fc-active"></span>)</button>
-    <button data-filter="recent" class="active">RECENT (<span id="fc-recent"></span>)</button>
-    <button data-filter="all">ALL (<span id="fc-all"></span>)</button>
+    <button data-filter="active" aria-pressed="false">ACTIVE (<span id="fc-active"></span>)</button>
+    <button data-filter="recent" class="active" aria-pressed="true">RECENT (<span id="fc-recent"></span>)</button>
+    <button data-filter="all" aria-pressed="false">ALL (<span id="fc-all"></span>)</button>
   `;
   filterBar.querySelectorAll('button').forEach((btn) => {
     btn.addEventListener('click', () => {
       activeFilter = btn.dataset.filter as typeof activeFilter;
-      filterBar.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
+      filterBar.querySelectorAll('button').forEach((b) => {
+        b.classList.remove('active');
+        b.setAttribute('aria-pressed', 'false');
+      });
       btn.classList.add('active');
+      btn.setAttribute('aria-pressed', 'true');
       renderList();
     });
   });
@@ -77,10 +81,9 @@ export function render(container: HTMLElement): void {
 
 function updateFilterBar(): void {
   el?.querySelectorAll('.session-filter-bar button').forEach((btn) => {
-    (btn as HTMLElement).classList.toggle(
-      'active',
-      (btn as HTMLElement).dataset.filter === activeFilter,
-    );
+    const isActive = (btn as HTMLElement).dataset.filter === activeFilter;
+    (btn as HTMLElement).classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
   });
 }
 
@@ -291,11 +294,21 @@ function renderList(): void {
 
     const header = document.createElement('div');
     header.className = 'time-group-header';
+    header.setAttribute('role', 'button');
+    header.setAttribute('tabindex', '0');
+    header.setAttribute('aria-expanded', String(!collapsedGroups.has(key)));
     header.innerHTML = `<span>${label}</span><span class="time-group-count">${filtered.length}</span>`;
     header.addEventListener('click', () => {
       group.classList.toggle('time-group-collapsed');
       if (group.classList.contains('time-group-collapsed')) collapsedGroups.add(key);
       else collapsedGroups.delete(key);
+      header.setAttribute('aria-expanded', String(!group.classList.contains('time-group-collapsed')));
+    });
+    header.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        header.click();
+      }
     });
     group.appendChild(header);
 

--- a/web/src/components/timeline-view.ts
+++ b/web/src/components/timeline-view.ts
@@ -80,6 +80,9 @@ function show(): void {
   wrapper.className = 'timeline-container';
 
   canvas = document.createElement('canvas');
+  canvas.setAttribute('role', 'img');
+  canvas.setAttribute('aria-label', 'Session timeline — horizontal lanes show user, assistant, and tool activity over time');
+  canvas.textContent = 'Session timeline visualization';
   wrapper.appendChild(canvas);
 
   tooltip = document.createElement('div');

--- a/web/src/components/topbar.ts
+++ b/web/src/components/topbar.ts
@@ -76,6 +76,11 @@ export function render(container: HTMLElement): void {
   hamburger.addEventListener('click', () => {
     const isOpen = collapsible.classList.toggle('open');
     hamburger.setAttribute('aria-expanded', String(isOpen));
+    // Toggle mobile sessions panel
+    const sessionsPanel = document.querySelector('.sessions-panel');
+    if (sessionsPanel) {
+      sessionsPanel.classList.toggle('open', isOpen);
+    }
   });
 
   // Escape key closes collapsible
@@ -85,6 +90,8 @@ export function render(container: HTMLElement): void {
       if (e.key === 'Escape' && collapsible.classList.contains('open')) {
         collapsible.classList.remove('open');
         hamburger.setAttribute('aria-expanded', 'false');
+        const sessionsPanel = document.querySelector('.sessions-panel');
+        if (sessionsPanel) sessionsPanel.classList.remove('open');
       }
     },
     { signal },

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -4,7 +4,7 @@
   --bg-hover: #1c2333;
   --border: #30363d;
   --text: #c9d1d9;
-  --text-dim: #8b949e;
+  --text-dim: #9da5ad;
   --green: #3fb950;
   --yellow: #d29922;
   --red: #f85149;
@@ -337,7 +337,7 @@ body {
 .update-banner-dismiss {
   background: none;
   border: none;
-  color: var(--fg-muted, #8b949e);
+  color: var(--fg-muted, #9da5ad);
   font-size: 18px;
   cursor: pointer;
   padding: 0 4px;
@@ -357,7 +357,7 @@ body {
 
 .history-subagent-toggle {
   font-size: 11px;
-  color: var(--fg-muted, #8b949e);
+  color: var(--fg-muted, #9da5ad);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -380,7 +380,7 @@ body {
   cursor: pointer;
   font-size: 10px;
   margin-right: 6px;
-  color: var(--fg-muted, #8b949e);
+  color: var(--fg-muted, #9da5ad);
   user-select: none;
 }
 
@@ -390,7 +390,7 @@ body {
 
 .history-subagent-badge {
   font-size: 10px;
-  color: var(--fg-muted, #8b949e);
+  color: var(--fg-muted, #9da5ad);
   margin-left: 8px;
   font-style: italic;
 }


### PR DESCRIPTION
## Summary

Fixes #174 — Accessibility: canvas views inaccessible, missing ARIA throughout

- **Canvas views** (graph-view, timeline-view): Added `role="img"`, descriptive `aria-label`, and fallback text content for screen readers
- **Session filter buttons** (ACTIVE/RECENT/ALL): Added `aria-pressed` state that updates on toggle
- **Feed filter buttons**: Added `aria-pressed` and `aria-label` for each filter type
- **Analytics card headers**: Added `role="button"`, `tabindex="0"`, `aria-expanded`, and keyboard handler (Enter/Space)
- **Time-group headers** (LAST HOUR, TODAY, etc.): Added `role="button"`, `aria-expanded`, `tabindex="0"`, and keyboard handler
- **Status bar**: Added `role="status"` and `aria-label`
- **Search dropdown**: Added `role="listbox"` to dropdown container, `role="option"` to result items
- **Color contrast**: Changed `--text-dim` from `#8b949e` to `#9da5ad` for >= 4.5:1 contrast ratio against `--bg` (`#0d1117`); also fixed `--fg-muted` fallbacks in base.css and `textDim` in colors.ts
- **Mobile sessions panel**: Hamburger button now toggles `.open` class on `.sessions-panel`

## Test plan

- [ ] Verify screen readers announce canvas views with descriptive labels
- [ ] Verify filter buttons report pressed/unpressed state to screen readers
- [ ] Verify analytics cards and time-group headers are keyboard-navigable (Tab, Enter, Space)
- [ ] Verify `--text-dim` colored text has sufficient contrast against the background
- [ ] Verify mobile hamburger menu opens/closes the sessions panel
- [ ] Run automated accessibility audit (axe, Lighthouse) and confirm no new violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)