### PR TITLE
perf: fix memory leaks, add debouncing, batch SQL flush

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -190,8 +190,9 @@ func (p *Pipeline) flush() {
 		log.Printf("batch persist error: %v", err)
 	}
 
-	// Persist affected sessions + repo mappings
+	// Persist affected sessions + repo mappings in a single transaction
 	seen := make(map[string]bool)
+	var sessionsToFlush []*session.Session
 	for _, ei := range batch {
 		if seen[ei.SessionID] {
 			continue
@@ -202,14 +203,10 @@ func (p *Pipeline) flush() {
 		if !ok {
 			continue
 		}
-		if err := p.db.SaveSession(sess); err != nil {
-			log.Printf("session save error for %s: %v", ei.SessionID, err)
-		}
-
-		// Persist repo mapping if we have a CWD and RepoID
-		if sess.CWD != "" && sess.RepoID != "" {
-			p.db.UpsertCwdRepo(sess.CWD, sess.RepoID)
-		}
+		sessionsToFlush = append(sessionsToFlush, sess)
+	}
+	if err := p.db.FlushSessions(sessionsToFlush); err != nil {
+		log.Printf("session flush error: %v", err)
 	}
 }
 

--- a/internal/repo/resolver.go
+++ b/internal/repo/resolver.go
@@ -11,6 +11,7 @@ import (
 )
 
 const gitTimeout = 2 * time.Second
+const maxCacheSize = 1000
 
 // Resolver resolves git repository identity from a working directory path.
 type Resolver struct {
@@ -43,6 +44,10 @@ func (r *Resolver) Resolve(cwd, label string) (*Repo, error) {
 	if cached, ok := r.cache[cwd]; ok {
 		r.mu.Unlock()
 		return cached, nil
+	}
+	// Simple size limit: clear entire cache if it exceeds maxCacheSize
+	if len(r.cache) >= maxCacheSize {
+		r.cache = make(map[string]*Repo)
 	}
 	r.cache[cwd] = resolved
 	r.mu.Unlock()

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -380,6 +380,95 @@ func (d *DB) SaveSession(s *session.Session) error {
 	return nil
 }
 
+// FlushSessions upserts multiple sessions and their cwd->repo mappings in a single transaction.
+func (d *DB) FlushSessions(sessions []*session.Session) error {
+	if len(sessions) == 0 {
+		return nil
+	}
+
+	tx, err := d.db.Begin()
+	if err != nil {
+		return fmt.Errorf("FlushSessions begin: %w", err)
+	}
+	defer func() {
+		if rbErr := tx.Rollback(); rbErr != nil && rbErr != sql.ErrTxDone {
+			log.Printf("FlushSessions: rollback error: %v", rbErr)
+		}
+	}()
+
+	sessStmt, err := tx.Prepare(`INSERT INTO sessions
+		(id, repo_id, parent_id, session_name, task_description, cwd, branch, model,
+		 started_at, ended_at, total_cost, input_tokens, output_tokens,
+		 cache_read_tokens, cache_creation_tokens, message_count, event_count, error_count,
+		 version, entrypoint)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+		 repo_id=excluded.repo_id,
+		 parent_id=excluded.parent_id,
+		 session_name=excluded.session_name,
+		 task_description=excluded.task_description,
+		 cwd=excluded.cwd,
+		 branch=excluded.branch,
+		 model=excluded.model,
+		 started_at=excluded.started_at,
+		 ended_at=excluded.ended_at,
+		 total_cost=excluded.total_cost,
+		 input_tokens=excluded.input_tokens,
+		 output_tokens=excluded.output_tokens,
+		 cache_read_tokens=excluded.cache_read_tokens,
+		 cache_creation_tokens=excluded.cache_creation_tokens,
+		 message_count=excluded.message_count,
+		 event_count=excluded.event_count,
+		 error_count=excluded.error_count,
+		 version=excluded.version,
+		 entrypoint=excluded.entrypoint`)
+	if err != nil {
+		return fmt.Errorf("FlushSessions prepare session: %w", err)
+	}
+	defer sessStmt.Close()
+
+	cwdStmt, err := tx.Prepare(`INSERT INTO cwd_repos (cwd, repo_id) VALUES (?, ?)
+		ON CONFLICT(cwd) DO UPDATE SET repo_id=excluded.repo_id`)
+	if err != nil {
+		return fmt.Errorf("FlushSessions prepare cwd: %w", err)
+	}
+	defer cwdStmt.Close()
+
+	for _, s := range sessions {
+		var endedAt string
+		var startedAt string
+		if !s.LastActive.IsZero() {
+			endedAt = s.LastActive.Format(time.RFC3339)
+		}
+		if !s.StartedAt.IsZero() {
+			startedAt = s.StartedAt.Format(time.RFC3339)
+		}
+
+		if _, err := sessStmt.Exec(
+			s.ID, s.RepoID, s.ParentID, s.SessionName, s.TaskDescription,
+			s.CWD, s.GitBranch, s.Model, startedAt, endedAt,
+			s.TotalCost, s.InputTokens, s.OutputTokens,
+			s.CacheReadTokens, s.CacheCreationTokens,
+			s.MessageCount, s.EventCount, s.ErrorCount,
+			s.Version, s.Entrypoint,
+		); err != nil {
+			return fmt.Errorf("FlushSessions save %s: %w", s.ID, err)
+		}
+
+		if s.CWD != "" && s.RepoID != "" {
+			if _, err := cwdStmt.Exec(s.CWD, s.RepoID); err != nil {
+				return fmt.Errorf("FlushSessions cwdRepo %s: %w", s.ID, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("FlushSessions commit: %w", err)
+	}
+	return nil
+}
+
+
 // LoadMessageDedup returns the message-ID dedup maps for a session from persisted events.
 // This is used to rebuild in-memory dedup state after a restart, preventing double-counting.
 func (d *DB) LoadMessageDedup(sessionID string) (map[string]bool, map[string]session.MessageCosts, error) {

--- a/web/index.html
+++ b/web/index.html
@@ -16,7 +16,7 @@
         <div class="feed-empty">Select a session to view its feed</div>
       </main>
     </div>
-    <footer id="statusbar">
+    <footer id="statusbar" role="status" aria-label="Application status">
       <div class="sb-item">
         <span class="sb-dot connected" id="conn-dot"></span>
         <span id="conn-indicator" class="connected">CONNECTED</span>

--- a/web/src/colors.ts
+++ b/web/src/colors.ts
@@ -5,7 +5,7 @@ export const COLORS = {
   bgCard: '#161b22',
   bgDeep: '#0f0f1a',
   text: '#c9d1d9',
-  textDim: '#8b949e',
+  textDim: '#9da5ad',
   green: '#3fb950',
   yellow: '#d29922',
   red: '#f85149',

--- a/web/src/components/analytics-cards.ts
+++ b/web/src/components/analytics-cards.ts
@@ -301,6 +301,9 @@ export function renderCards(
 
     const header = document.createElement('div');
     header.className = 'analytics-card-header';
+    header.setAttribute('role', 'button');
+    header.setAttribute('tabindex', '0');
+    header.setAttribute('aria-expanded', String(expanded));
     header.innerHTML = `
       <span class="analytics-card-toggle">${expanded ? '▼' : '▶'}</span>
       <span class="analytics-card-title">${def.title}</span>
@@ -331,6 +334,7 @@ export function renderCards(
         // Collapse
         body.style.display = 'none';
         header.querySelector('.analytics-card-toggle')!.textContent = '▶';
+        header.setAttribute('aria-expanded', 'false');
         const existing = charts.get(def.id);
         if (existing) {
           existing.destroy();
@@ -341,9 +345,16 @@ export function renderCards(
         // Expand
         body.style.display = '';
         header.querySelector('.analytics-card-toggle')!.textContent = '▼';
+        header.setAttribute('aria-expanded', 'true');
         const chart = def.render(canvas, data);
         charts.set(def.id, chart);
         onToggle(def.id, true);
+      }
+    });
+    header.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        header.click();
       }
     });
   }

--- a/web/src/components/feed-panel.ts
+++ b/web/src/components/feed-panel.ts
@@ -27,6 +27,7 @@ const MAX_ENTRIES = 500;
 // Maps toolUseId -> displayType so tool_result messages can inherit their
 // originating tool_use call's display type for consistent grouping/styling.
 const toolUseMap = new Map<string, string>(); // toolUseId -> displayType
+const MAX_TOOL_USE_MAP = 200;
 
 const FILTER_TYPES = [
   'all',
@@ -41,6 +42,7 @@ const FILTER_TYPES = [
 ] as const;
 
 let multiSessionLoaded = false;
+let scrollRafPending = false;
 
 export function render(mount: HTMLElement): void {
   container = mount;
@@ -69,6 +71,16 @@ function onStateChange(_state: AppState, changed: Set<string>): void {
     if (sessionChanged && feedContent) {
       const prevId = currentLoadSessionId || '__multi__';
       scrollPositions.set(prevId, feedContent.scrollTop);
+    }
+
+    // Clean up toolUseMap on session switch (tool_results from the old session won't arrive)
+    toolUseMap.clear();
+
+    // Prune scrollPositions for sessions no longer in state
+    for (const key of scrollPositions.keys()) {
+      if (key !== '__multi__' && !state.sessions.has(key)) {
+        scrollPositions.delete(key);
+      }
     }
 
     if (state.selectedSessionId) {
@@ -148,11 +160,16 @@ function renderFeedPanel(): void {
     ? '<div class="feed-empty">Waiting for events in this session\u2026</div>'
     : '<div class="feed-empty">Select a session to view its event feed</div>';
   feedContent.addEventListener('scroll', () => {
-    if (!feedContent) return;
-    const atBottom =
-      feedContent.scrollHeight - feedContent.scrollTop - feedContent.clientHeight < 30;
-    autoScroll = atBottom;
-    scrollLockBtn?.classList.toggle('visible', !atBottom);
+    if (scrollRafPending) return;
+    scrollRafPending = true;
+    requestAnimationFrame(() => {
+      scrollRafPending = false;
+      if (!feedContent) return;
+      const atBottom =
+        feedContent.scrollHeight - feedContent.scrollTop - feedContent.clientHeight < 30;
+      autoScroll = atBottom;
+      scrollLockBtn?.classList.toggle('visible', !atBottom);
+    });
   });
   // Hover-based group highlighting: hovering any entry with a data-group-id
   // highlights all entries in the same group (tool_use + hooks + tool_result).
@@ -367,13 +384,20 @@ async function loadMultiSessionEvents(): Promise<void> {
   if (activeSessions.length === 0) return;
 
   try {
-    // Fetch last 20 events from each active session
-    const perSession = await Promise.all(
-      activeSessions.map(async (sess) => {
-        const events = await fetchSessionEvents(sess.id, 20);
-        return events.map((e) => ({ ...e, _sessionName: sessionDisplayName(sess) }));
-      }),
-    );
+    // Fetch last 20 events from each active session (max 5 concurrent)
+    const MAX_CONCURRENT = 5;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const perSession: any[][] = [];
+    for (let i = 0; i < activeSessions.length; i += MAX_CONCURRENT) {
+      const chunk = activeSessions.slice(i, i + MAX_CONCURRENT);
+      const results = await Promise.all(
+        chunk.map(async (sess) => {
+          const events = await fetchSessionEvents(sess.id, 20);
+          return events.map((e) => ({ ...e, _sessionName: sessionDisplayName(sess) }));
+        }),
+      );
+      perSession.push(...results);
+    }
 
     const allEvents = perSession
       .flat()
@@ -428,6 +452,16 @@ function appendMessage(msg: ParsedMessage, opts: { showSessionId?: string } = {}
   // inherit their display type from the originating tool_use call.
   if (msg.toolName && msg.role === 'assistant' && msg.toolUseId) {
     toolUseMap.set(msg.toolUseId, detectType(msg));
+    // Evict oldest entries if map grows too large (orphaned tool_use without results)
+    if (toolUseMap.size > MAX_TOOL_USE_MAP) {
+      const half = MAX_TOOL_USE_MAP / 2;
+      const toDelete: string[] = [];
+      for (const k of toolUseMap.keys()) {
+        if (toDelete.length >= half) break;
+        toDelete.push(k);
+      }
+      for (const k of toDelete) toolUseMap.delete(k);
+    }
   }
 
   const entry = renderFeedEntry(msg, opts);

--- a/web/src/components/feed-panel.ts
+++ b/web/src/components/feed-panel.ts
@@ -124,9 +124,12 @@ function renderFeedPanel(): void {
   filterBar.className = 'feed-type-filters';
   for (const type of FILTER_TYPES) {
     const btn = document.createElement('button');
-    btn.className = `feed-filter-btn ${type === 'all' ? 'all-btn' : ''} ${type === 'all' || state.feedTypeFilters[type] ? 'active' : ''}`;
+    const isActive = type === 'all' || state.feedTypeFilters[type];
+    btn.className = `feed-filter-btn ${type === 'all' ? 'all-btn' : ''} ${isActive ? 'active' : ''}`;
     btn.textContent = type.toUpperCase();
     btn.dataset.type = type;
+    btn.setAttribute('aria-pressed', String(!!isActive));
+    btn.setAttribute('aria-label', `Filter by ${type.replace('_', ' ')} messages`);
     btn.addEventListener('click', (e) => handleFilterClick(type, e as MouseEvent));
     filterBar!.appendChild(btn);
   }
@@ -255,7 +258,9 @@ function updateFilterButtons(): void {
   filterBar.querySelectorAll<HTMLButtonElement>('.feed-filter-btn').forEach((btn) => {
     const t = btn.dataset.type!;
     if (t === 'all') return;
-    btn.classList.toggle('active', state.feedTypeFilters[t] ?? true);
+    const isActive = state.feedTypeFilters[t] ?? true;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
   });
 }
 

--- a/web/src/components/graph-view.ts
+++ b/web/src/components/graph-view.ts
@@ -89,6 +89,9 @@ function show(): void {
 
   if (graphMode === 'graph') {
     canvas = document.createElement('canvas');
+    canvas.setAttribute('role', 'img');
+    canvas.setAttribute('aria-label', 'Session dependency graph — nodes represent active sessions, edges show parent-child relationships');
+    canvas.textContent = 'Session dependency graph visualization';
     wrapper.appendChild(canvas);
 
     tooltip = document.createElement('div');

--- a/web/src/components/search.ts
+++ b/web/src/components/search.ts
@@ -11,6 +11,8 @@ let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 export function render(searchBoxEl: HTMLElement): void {
   dropdown = document.createElement('div');
   dropdown.className = 'search-dropdown search-dropdown-hidden';
+  dropdown.setAttribute('role', 'listbox');
+  dropdown.setAttribute('aria-label', 'Search results');
   searchBoxEl.appendChild(dropdown);
 
   subscribe(onStateChange);
@@ -93,6 +95,7 @@ function renderResults(): void {
     for (const result of visibleResults) {
       const el = document.createElement('div');
       el.className = 'search-result';
+      el.setAttribute('role', 'option');
       el.innerHTML = `
         <div class="search-result-header">
           <span class="search-result-session">${escapeHtml(group.name)}</span>

--- a/web/src/components/session-list.ts
+++ b/web/src/components/session-list.ts
@@ -31,6 +31,7 @@ export function render(container: HTMLElement): void {
   filterBar.querySelectorAll('button').forEach((btn) => {
     btn.addEventListener('click', () => {
       activeFilter = btn.dataset.filter as typeof activeFilter;
+      showAllGroups.clear(); // Reset "show all" expansion when switching filters
       filterBar.querySelectorAll('button').forEach((b) => {
         b.classList.remove('active');
         b.setAttribute('aria-pressed', 'false');
@@ -62,16 +63,19 @@ export function render(container: HTMLElement): void {
     if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
     if (e.key === '1') {
       activeFilter = 'active';
+      showAllGroups.clear();
       renderList();
       updateFilterBar();
     }
     if (e.key === '2') {
       activeFilter = 'recent';
+      showAllGroups.clear();
       renderList();
       updateFilterBar();
     }
     if (e.key === '3') {
       activeFilter = 'all';
+      showAllGroups.clear();
       renderList();
       updateFilterBar();
     }

--- a/web/src/components/session-list.ts
+++ b/web/src/components/session-list.ts
@@ -24,15 +24,19 @@ export function render(container: HTMLElement): void {
   const filterBar = document.createElement('div');
   filterBar.className = 'session-filter-bar';
   filterBar.innerHTML = `
-    <button data-filter="active">ACTIVE (<span id="fc-active"></span>)</button>
-    <button data-filter="recent" class="active">RECENT (<span id="fc-recent"></span>)</button>
-    <button data-filter="all">ALL (<span id="fc-all"></span>)</button>
+    <button data-filter="active" aria-pressed="false">ACTIVE (<span id="fc-active"></span>)</button>
+    <button data-filter="recent" class="active" aria-pressed="true">RECENT (<span id="fc-recent"></span>)</button>
+    <button data-filter="all" aria-pressed="false">ALL (<span id="fc-all"></span>)</button>
   `;
   filterBar.querySelectorAll('button').forEach((btn) => {
     btn.addEventListener('click', () => {
       activeFilter = btn.dataset.filter as typeof activeFilter;
-      filterBar.querySelectorAll('button').forEach((b) => b.classList.remove('active'));
+      filterBar.querySelectorAll('button').forEach((b) => {
+        b.classList.remove('active');
+        b.setAttribute('aria-pressed', 'false');
+      });
       btn.classList.add('active');
+      btn.setAttribute('aria-pressed', 'true');
       renderList();
     });
   });
@@ -77,10 +81,9 @@ export function render(container: HTMLElement): void {
 
 function updateFilterBar(): void {
   el?.querySelectorAll('.session-filter-bar button').forEach((btn) => {
-    (btn as HTMLElement).classList.toggle(
-      'active',
-      (btn as HTMLElement).dataset.filter === activeFilter,
-    );
+    const isActive = (btn as HTMLElement).dataset.filter === activeFilter;
+    (btn as HTMLElement).classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
   });
 }
 
@@ -291,11 +294,21 @@ function renderList(): void {
 
     const header = document.createElement('div');
     header.className = 'time-group-header';
+    header.setAttribute('role', 'button');
+    header.setAttribute('tabindex', '0');
+    header.setAttribute('aria-expanded', String(!collapsedGroups.has(key)));
     header.innerHTML = `<span>${label}</span><span class="time-group-count">${filtered.length}</span>`;
     header.addEventListener('click', () => {
       group.classList.toggle('time-group-collapsed');
       if (group.classList.contains('time-group-collapsed')) collapsedGroups.add(key);
       else collapsedGroups.delete(key);
+      header.setAttribute('aria-expanded', String(!group.classList.contains('time-group-collapsed')));
+    });
+    header.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        header.click();
+      }
     });
     group.appendChild(header);
 

--- a/web/src/components/timeline-view.ts
+++ b/web/src/components/timeline-view.ts
@@ -80,6 +80,9 @@ function show(): void {
   wrapper.className = 'timeline-container';
 
   canvas = document.createElement('canvas');
+  canvas.setAttribute('role', 'img');
+  canvas.setAttribute('aria-label', 'Session timeline — horizontal lanes show user, assistant, and tool activity over time');
+  canvas.textContent = 'Session timeline visualization';
   wrapper.appendChild(canvas);
 
   tooltip = document.createElement('div');

--- a/web/src/components/topbar.ts
+++ b/web/src/components/topbar.ts
@@ -76,6 +76,11 @@ export function render(container: HTMLElement): void {
   hamburger.addEventListener('click', () => {
     const isOpen = collapsible.classList.toggle('open');
     hamburger.setAttribute('aria-expanded', String(isOpen));
+    // Toggle mobile sessions panel
+    const sessionsPanel = document.querySelector('.sessions-panel');
+    if (sessionsPanel) {
+      sessionsPanel.classList.toggle('open', isOpen);
+    }
   });
 
   // Escape key closes collapsible
@@ -85,6 +90,8 @@ export function render(container: HTMLElement): void {
       if (e.key === 'Escape' && collapsible.classList.contains('open')) {
         collapsible.classList.remove('open');
         hamburger.setAttribute('aria-expanded', 'false');
+        const sessionsPanel = document.querySelector('.sessions-panel');
+        if (sessionsPanel) sessionsPanel.classList.remove('open');
       }
     },
     { signal },

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -4,7 +4,7 @@
   --bg-hover: #1c2333;
   --border: #30363d;
   --text: #c9d1d9;
-  --text-dim: #8b949e;
+  --text-dim: #9da5ad;
   --green: #3fb950;
   --yellow: #d29922;
   --red: #f85149;
@@ -337,7 +337,7 @@ body {
 .update-banner-dismiss {
   background: none;
   border: none;
-  color: var(--fg-muted, #8b949e);
+  color: var(--fg-muted, #9da5ad);
   font-size: 18px;
   cursor: pointer;
   padding: 0 4px;
@@ -357,7 +357,7 @@ body {
 
 .history-subagent-toggle {
   font-size: 11px;
-  color: var(--fg-muted, #8b949e);
+  color: var(--fg-muted, #9da5ad);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -380,7 +380,7 @@ body {
   cursor: pointer;
   font-size: 10px;
   margin-right: 6px;
-  color: var(--fg-muted, #8b949e);
+  color: var(--fg-muted, #9da5ad);
   user-select: none;
 }
 
@@ -390,7 +390,7 @@ body {
 
 .history-subagent-badge {
   font-size: 10px;
-  color: var(--fg-muted, #8b949e);
+  color: var(--fg-muted, #9da5ad);
   margin-left: 8px;
   font-style: italic;
 }


### PR DESCRIPTION
## Summary

Fixes #175: Performance improvements targeting the most impactful items from the issue.

**Frontend memory leaks (unbounded maps):**
- `toolUseMap`: cleared on session switch; evicts oldest half when exceeding 200 entries
- `scrollPositions`: pruned of stale session entries on each session switch
- `showAllGroups` set: cleared when filter changes (button click or keyboard shortcut)

**Frontend debouncing/throttling:**
- Scroll handler: wrapped in `requestAnimationFrame` throttle to avoid per-frame DOM reads
- `loadMultiSessionEvents`: limited to 5 concurrent fetch requests (chunked `Promise.all`)

**Backend unbounded cache:**
- `Resolver.cache`: cleared entirely when exceeding 1000 entries (simple and effective vs LRU)

**Backend batch SQL flush:**
- New `FlushSessions` method wraps all session upserts + cwd-repo mappings in a single SQLite transaction, replacing N individual transactions per flush cycle

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (pre-existing `TestTrendBuckets_DailyGrouping` failure unrelated)
- [ ] Verify feed scroll behavior works correctly with RAF throttle
- [ ] Open app with many sessions, switch between them, verify no memory growth in DevTools
- [ ] Verify "SHOW ALL" button resets when switching between Active/Recent/All filters

Generated with [Claude Code](https://claude.com/claude-code)