### PR TITLE
test: add store and handler tests, fix test race conditions

### DIFF
--- a/cmd/claude-monitor/main_test.go
+++ b/cmd/claude-monitor/main_test.go
@@ -369,3 +369,110 @@ func TestSwaggerEndpoint(t *testing.T) {
 		t.Errorf("expected status 404 for /swagger, got %d", resp.StatusCode)
 	}
 }
+
+// TestStorage verifies GET /api/storage returns 200 and storage info fields.
+func TestStorage(t *testing.T) {
+	t.Parallel()
+
+	var body map[string]interface{}
+	getJSON(t, "/api/storage", &body)
+
+	for _, key := range []string{"totalSizeBytes", "hotContentBytes", "warmContentBytes", "eventCount"} {
+		if _, ok := body[key]; !ok {
+			t.Errorf("response missing expected key %q", key)
+		}
+	}
+
+	// All values should be non-negative numbers.
+	for _, key := range []string{"totalSizeBytes", "eventCount"} {
+		val, ok := body[key].(float64)
+		if !ok {
+			continue
+		}
+		if val < 0 {
+			t.Errorf("%s is negative: %f", key, val)
+		}
+	}
+}
+
+// TestSessionByID_NotFound verifies GET /api/sessions/{id} returns 404 for
+// an unknown session ID.
+func TestSessionByID_NotFound(t *testing.T) {
+	t.Parallel()
+
+	resp, err := http.Get(baseURL + "/api/sessions/nonexistent-session-id-12345")
+	if err != nil {
+		t.Fatalf("GET /api/sessions/{id} failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected status 404, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if body["error"] != "session not found" {
+		t.Errorf("expected error message %q, got %q", "session not found", body["error"])
+	}
+}
+
+// TestSettingsUpdate verifies PUT /api/settings/{key} accepts a valid update.
+func TestSettingsUpdate(t *testing.T) {
+	t.Parallel()
+
+	body := strings.NewReader(`{"value":"7"}`)
+	req, err := http.NewRequest(http.MethodPut, baseURL+"/api/settings/retention_hot_days", body)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT /api/settings/retention_hot_days failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]bool
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !result["ok"] {
+		t.Error("expected ok=true in response")
+	}
+}
+
+// TestCacheClear verifies DELETE /api/cache/repos returns 200 with ok=true.
+func TestCacheClear(t *testing.T) {
+	t.Parallel()
+
+	req, err := http.NewRequest(http.MethodDelete, baseURL+"/api/cache/repos", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE /api/cache/repos failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", resp.StatusCode)
+	}
+
+	var result map[string]bool
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !result["ok"] {
+		t.Error("expected ok=true in response")
+	}
+}

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -481,7 +481,7 @@ func TestWatch_EmptyInitialPoll(t *testing.T) {
 func TestWatch_DetectsAddedAndRemovedPaths(t *testing.T) {
 	t.Parallel()
 
-	pollCount := 0
+	var pollCount atomic.Int64
 	responses := []string{
 		// Initial poll: one container
 		`[{
@@ -498,12 +498,12 @@ func TestWatch_DetectsAddedAndRemovedPaths(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/containers/json", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		idx := pollCount
+		idx := int(pollCount.Load())
 		if idx >= len(responses) {
 			idx = len(responses) - 1
 		}
 		fmt.Fprint(w, responses[idx])
-		pollCount++
+		pollCount.Add(1)
 	})
 
 	client, cleanup := newTestClient(t, mux)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -2266,3 +2266,143 @@ func TestClosedDB_UpsertCwdRepo(t *testing.T) {
 		t.Error("expected error from closed DB, got nil")
 	}
 }
+
+// =============================================================================
+// Additional coverage: GetSession field verification
+// =============================================================================
+
+func TestGetSession_AllFields(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now()
+	sess := &session.Session{
+		ID:              "get-all-1",
+		SessionName:     "full field test",
+		TotalCost:       3.14,
+		InputTokens:     500,
+		OutputTokens:    250,
+		CacheReadTokens: 100,
+		MessageCount:    5,
+		ErrorCount:      1,
+		StartedAt:       now.Add(-10 * time.Minute),
+		LastActive:      now,
+		Model:           "claude-sonnet-4-6",
+		CWD:             "/home/user/project",
+		GitBranch:       "feature/test",
+		TaskDescription: "Implement feature X",
+	}
+	if err := db.SaveSession(sess); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+
+	row, err := db.GetSession("get-all-1")
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if row == nil {
+		t.Fatal("expected session row, got nil")
+	}
+	if row.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model: got %q, want %q", row.Model, "claude-sonnet-4-6")
+	}
+	if row.CWD != "/home/user/project" {
+		t.Errorf("CWD: got %q, want %q", row.CWD, "/home/user/project")
+	}
+	if row.Branch != "feature/test" {
+		t.Errorf("Branch: got %q, want %q", row.Branch, "feature/test")
+	}
+	if row.TaskDescription != "Implement feature X" {
+		t.Errorf("TaskDescription: got %q, want %q", row.TaskDescription, "Implement feature X")
+	}
+	if row.InputTokens != 500 {
+		t.Errorf("InputTokens: got %d, want 500", row.InputTokens)
+	}
+	if row.ErrorCount != 1 {
+		t.Errorf("ErrorCount: got %d, want 1", row.ErrorCount)
+	}
+}
+
+// =============================================================================
+// Additional coverage: SearchFullContent special characters
+// =============================================================================
+
+func TestSearchFullContent_SpecialCharacters(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	db.SaveSession(&session.Session{
+		ID: "sfc-special", StartedAt: time.Now(), LastActive: time.Now(),
+	})
+
+	batch := &EventBatch{Events: []EventInsert{{
+		SessionID: "sfc-special",
+		Event: &parser.Event{
+			Type:        "assistant",
+			ContentText: "special chars",
+			Timestamp:   time.Now(),
+			UUID:        "sfc-special-uuid",
+		},
+		FullContent: "line with 100% match and $pecial ch@racters",
+	}}}
+	db.PersistBatch(batch)
+
+	results, err := db.SearchFullContent("$pecial ch@racters", 10)
+	if err != nil {
+		t.Fatalf("SearchFullContent: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 result for special characters, got %d", len(results))
+	}
+}
+
+// =============================================================================
+// Additional coverage: ListSessionsByRepo empty and pagination
+// =============================================================================
+
+func TestListSessionsByRepo_Empty(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	rows, err := db.ListSessionsByRepo("nonexistent-repo", 10, 0)
+	if err != nil {
+		t.Fatalf("ListSessionsByRepo: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 sessions for nonexistent repo, got %d", len(rows))
+	}
+}
+
+func TestListSessionsByRepo_Pagination(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		insertTestSessionWithRepo(t, db, fmt.Sprintf("lsr-pg-%d", i), "repo-paged",
+			now.Add(-time.Duration(i)*time.Hour), float64(i+1), 100, 50, 30, 10)
+	}
+
+	// First page
+	page1, err := db.ListSessionsByRepo("repo-paged", 2, 0)
+	if err != nil {
+		t.Fatalf("ListSessionsByRepo page 1: %v", err)
+	}
+	if len(page1) != 2 {
+		t.Fatalf("page 1: expected 2, got %d", len(page1))
+	}
+
+	// Second page
+	page2, err := db.ListSessionsByRepo("repo-paged", 2, 2)
+	if err != nil {
+		t.Fatalf("ListSessionsByRepo page 2: %v", err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("page 2: expected 2, got %d", len(page2))
+	}
+
+	// Pages should have different sessions
+	if page1[0].ID == page2[0].ID {
+		t.Error("page 1 and page 2 returned the same first session")
+	}
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -36,6 +36,8 @@ func TestCheckLatest_NewerAvailable(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	origURL := apiURL
+	t.Cleanup(func() { apiURL = origURL })
 	apiURL = srv.URL
 	rel, err := CheckLatest("v1.0.0")
 	if err != nil {
@@ -61,6 +63,8 @@ func TestCheckLatest_AlreadyCurrent(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	origURL := apiURL
+	t.Cleanup(func() { apiURL = origURL })
 	apiURL = srv.URL
 	rel, err := CheckLatest("v1.0.0")
 	if err != nil {
@@ -87,6 +91,8 @@ func TestCheckLatest_ServerError(t *testing.T) {
 	}))
 	defer srv.Close()
 
+	origURL := apiURL
+	t.Cleanup(func() { apiURL = origURL })
 	apiURL = srv.URL
 	_, err := CheckLatest("v1.0.0")
 	if err == nil {


### PR DESCRIPTION
## Summary
- **Store tests**: Add `TestGetSession_AllFields` (field verification), `TestSearchFullContent_SpecialCharacters`, `TestListSessionsByRepo_Empty`, and `TestListSessionsByRepo_Pagination`
- **Handler tests**: Add `TestStorage` (GET /api/storage), `TestSessionByID_NotFound` (404 case), `TestSettingsUpdate` (PUT /api/settings/{key}), and `TestCacheClear` (DELETE /api/cache/repos)
- **Race fix**: Change `pollCount` in `docker_test.go` from bare `int` to `atomic.Int64` to eliminate data race between handler goroutine and test goroutine
- **Cleanup fix**: Add `t.Cleanup` in `update_test.go` to restore `apiURL` after each test mutates it

## Test plan
- [x] `go test -race ./internal/store/` -- new tests pass, race detector clean
- [x] `go test -race ./internal/docker/` -- race condition fixed, all tests pass
- [x] `go test -race ./internal/update/` -- cleanup restores global state
- [x] `go test -race ./internal/...` -- full suite passes (2 pre-existing failures unrelated to this PR)
- [x] Only `*_test.go` files modified -- no production code changes

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)