### PR TITLE
security: fix LIKE injection, request limits, settings allowlist

### DIFF
--- a/cmd/claude-monitor/handlers.go
+++ b/cmd/claude-monitor/handlers.go
@@ -321,7 +321,7 @@ func handleRepoSessions(historyDB *store.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		repoID := r.PathValue("id")
 		limit := defaultPageLimit
-		if n, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && n > 0 {
+		if n, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && n > 0 && n <= 500 {
 			limit = n
 		}
 		offset := 0
@@ -432,7 +432,7 @@ func handleSessionEvents(historyDB *store.DB) http.HandlerFunc {
 		}
 
 		limit := 100
-		if n, err := strconv.Atoi(q.Get("limit")); err == nil && n > 0 {
+		if n, err := strconv.Atoi(q.Get("limit")); err == nil && n > 0 && n <= 500 {
 			limit = n
 		}
 		offset := 0
@@ -455,7 +455,16 @@ func handleSessionEvents(historyDB *store.DB) http.HandlerFunc {
 func handleSessionReplay(historyDB *store.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("id")
-		events, err := historyDB.ListEvents(id, 10000, 0)
+		q := r.URL.Query()
+		limit := 1000
+		if n, err := strconv.Atoi(q.Get("limit")); err == nil && n > 0 && n <= 10000 {
+			limit = n
+		}
+		offset := 0
+		if n, err := strconv.Atoi(q.Get("offset")); err == nil && n >= 0 {
+			offset = n
+		}
+		events, err := historyDB.ListEvents(id, limit, offset)
 		if err != nil {
 			writeJSONError(w, "failed to list events", http.StatusInternalServerError)
 			return
@@ -466,6 +475,8 @@ func handleSessionReplay(historyDB *store.DB) http.HandlerFunc {
 		writeJSON(w, map[string]any{
 			"sessionId": id,
 			"events":    events,
+			"limit":     limit,
+			"offset":    offset,
 		})
 	}
 }
@@ -482,10 +493,21 @@ func handleSettings(historyDB *store.DB) http.HandlerFunc {
 	}
 }
 
+// validSettingKeys is the allowlist of setting keys that can be updated via the API.
+var validSettingKeys = map[string]bool{
+	"retention_hot_days":  true,
+	"retention_warm_days": true,
+}
+
 // handleSettingsUpdate serves PUT /api/settings/{key}.
 func handleSettingsUpdate(historyDB *store.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		key := r.PathValue("key")
+		if !validSettingKeys[key] {
+			writeJSONError(w, "unknown setting key", http.StatusBadRequest)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB limit
 		var body struct {
 			Value string `json:"value"`
 		}

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -229,30 +229,6 @@ func (r *statusRecorder) WriteHeader(code int) {
 	r.ResponseWriter.WriteHeader(code)
 }
 
-// corsMiddleware adds CORS headers to API responses, restricting cross-origin
-// access to same-origin by default. Since the frontend is served from the same
-// origin this is primarily a defense-in-depth measure.
-func corsMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, "/api/") {
-			origin := r.Header.Get("Origin")
-			if origin != "" {
-				// Only allow the request's own origin (same-origin policy).
-				w.Header().Set("Access-Control-Allow-Origin", origin)
-				w.Header().Set("Vary", "Origin")
-				w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-				w.Header().Set("Access-Control-Max-Age", "86400")
-			}
-			if r.Method == http.MethodOptions {
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-		}
-		next.ServeHTTP(w, r)
-	})
-}
-
 // loggingMiddleware logs method, path, status code, and duration for each request.
 // Long-lived connections (WebSocket and SSE) are passed through without logging.
 func loggingMiddleware(next http.Handler) http.Handler {
@@ -576,7 +552,7 @@ Examples:
 	addr := fmt.Sprintf("%s:%d", *bind, *port)
 	srv := &http.Server{
 		Addr:        addr,
-		Handler:     loggingMiddleware(corsMiddleware(mux)),
+		Handler:     loggingMiddleware(mux),
 		ReadTimeout: 15 * time.Second,
 		IdleTimeout: 60 * time.Second,
 		// WriteTimeout intentionally omitted: WebSocket (54s ping) and SSE

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -229,6 +229,30 @@ func (r *statusRecorder) WriteHeader(code int) {
 	r.ResponseWriter.WriteHeader(code)
 }
 
+// corsMiddleware adds CORS headers to API responses, restricting cross-origin
+// access to same-origin by default. Since the frontend is served from the same
+// origin this is primarily a defense-in-depth measure.
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/api/") {
+			origin := r.Header.Get("Origin")
+			if origin != "" {
+				// Only allow the request's own origin (same-origin policy).
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+				w.Header().Set("Vary", "Origin")
+				w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, POST, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+				w.Header().Set("Access-Control-Max-Age", "86400")
+			}
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // loggingMiddleware logs method, path, status code, and duration for each request.
 // Long-lived connections (WebSocket and SSE) are passed through without logging.
 func loggingMiddleware(next http.Handler) http.Handler {
@@ -552,7 +576,7 @@ Examples:
 	addr := fmt.Sprintf("%s:%d", *bind, *port)
 	srv := &http.Server{
 		Addr:        addr,
-		Handler:     loggingMiddleware(mux),
+		Handler:     loggingMiddleware(corsMiddleware(mux)),
 		ReadTimeout: 15 * time.Second,
 		IdleTimeout: 60 * time.Second,
 		// WriteTimeout intentionally omitted: WebSocket (54s ping) and SSE

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -1252,13 +1252,15 @@ func (d *DB) SearchFullContent(query string, limit int) ([]EventRow, error) {
 	if limit <= 0 {
 		limit = 50
 	}
+	// Escape LIKE wildcards to prevent injection of % and _ characters.
+	escaped := strings.NewReplacer(`%`, `\%`, `_`, `\_`).Replace(query)
 	rows, err := d.db.Query(`SELECT `+eventSelectCols+`,
 		COALESCE(ec.content,''), ec.compressed
 		FROM event_content ec
 		JOIN events e ON e.id = ec.event_id
-		WHERE ec.content LIKE ?
+		WHERE ec.content LIKE ? ESCAPE '\'
 		ORDER BY e.timestamp DESC
-		LIMIT ?`, "%"+query+"%", limit)
+		LIMIT ?`, "%"+escaped+"%", limit)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- **LIKE injection fix**: Escape `%` and `_` wildcards in `SearchFullContent` to prevent LIKE injection in full-content search
- **Request body size limit**: Add `http.MaxBytesReader` (1MB) to settings update endpoint
- **Settings allowlist**: Only `retention_hot_days` and `retention_warm_days` can be updated via API
- **Limit validation**: Add upper bound caps to `handleRepoSessions` (500), `handleSessionEvents` (500), and `handleSessionReplay` (default 1000, max 10000 with pagination)
- **CORS middleware**: Defense-in-depth CORS headers on `/api/` routes

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./cmd/claude-monitor/` passes (all handler tests)
- [ ] Verify `PUT /api/settings/invalid_key` returns 400
- [ ] Verify `GET /api/search/full?q=%25` does not match all rows
- [ ] Verify `GET /api/sessions/{id}/replay?limit=100&offset=0` returns paginated results

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)