### PR TITLE
fix: install script binary lookup, table view, replay UI, keyboard shortcuts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,9 +40,17 @@ trap 'rm -rf "$TMPDIR"' EXIT
 curl -fsSL "$URL" -o "${TMPDIR}/${BINARY}.tar.gz"
 tar xzf "${TMPDIR}/${BINARY}.tar.gz" -C "$TMPDIR"
 
-# Install
+# Install — tarball may contain the binary as 'claude-monitor' (Homebrew-style)
+# or as the full platform name 'claude-monitor-OS-ARCH' (release.yml-style)
 mkdir -p "$INSTALL_DIR"
-mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/claude-monitor"
+if [ -f "${TMPDIR}/claude-monitor" ]; then
+  mv "${TMPDIR}/claude-monitor" "${INSTALL_DIR}/claude-monitor"
+elif [ -f "${TMPDIR}/${BINARY}" ]; then
+  mv "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/claude-monitor"
+else
+  echo "Error: could not find binary in archive (looked for 'claude-monitor' and '${BINARY}')"
+  exit 1
+fi
 chmod +x "${INSTALL_DIR}/claude-monitor"
 
 # macOS: remove quarantine attribute

--- a/web/src/components/feed-panel.ts
+++ b/web/src/components/feed-panel.ts
@@ -8,6 +8,7 @@ import { renderFeedEntry, detectType } from './render-message';
 import { escapeHtml, sessionDisplayName } from '../utils';
 import { setLastTool } from '../tool-tracker';
 import { notify } from '../notifications';
+import { open as openReplay } from './replay';
 import '../styles/feed.css';
 
 let container: HTMLElement | null = null;
@@ -214,6 +215,7 @@ function updateHeader(): void {
     headerEl.innerHTML = `<span style="color:var(--cyan);letter-spacing:1px">${label}</span>
       <span style="color:var(--text-dim);font-size:10px;letter-spacing:0.5px">${escapeHtml(name)}</span>
       <span class="timeline-btn" role="button" tabindex="0" aria-label="Open timeline view" style="margin-left:8px;color:var(--yellow);font-size:9px;cursor:pointer;border:1px solid rgba(255,204,0,0.3);padding:1px 6px;border-radius:2px;letter-spacing:0.5px">TIMELINE</span>
+      <span class="replay-btn" role="button" tabindex="0" aria-label="Open session replay" style="margin-left:6px;color:var(--green);font-size:9px;cursor:pointer;border:1px solid rgba(63,185,80,0.3);padding:1px 6px;border-radius:2px;letter-spacing:0.5px">REPLAY</span>
       <span class="back-to-feed" role="button" tabindex="0" aria-label="Back to all sessions" style="margin-left:auto;color:var(--cyan);font-size:10px;cursor:pointer;letter-spacing:0.5px">← ALL</span>`;
     const backBtn = headerEl.querySelector('.back-to-feed');
     backBtn?.addEventListener('click', () => {
@@ -233,6 +235,16 @@ function updateHeader(): void {
       if ((e as KeyboardEvent).key === 'Enter' || (e as KeyboardEvent).key === ' ') {
         e.preventDefault();
         if (state.selectedSessionId) update({ view: 'timeline' });
+      }
+    });
+    const replayBtn = headerEl.querySelector('.replay-btn');
+    replayBtn?.addEventListener('click', () => {
+      if (state.selectedSessionId) openReplay(state.selectedSessionId);
+    });
+    replayBtn?.addEventListener('keydown', (e) => {
+      if ((e as KeyboardEvent).key === 'Enter' || (e as KeyboardEvent).key === ' ') {
+        e.preventDefault();
+        if (state.selectedSessionId) openReplay(state.selectedSessionId);
       }
     });
   } else {

--- a/web/src/components/help-overlay.ts
+++ b/web/src/components/help-overlay.ts
@@ -41,6 +41,11 @@ export function toggle(): void {
       <div class="help-row"><span>Graph view</span><kbd>g</kbd></div>
       <div class="help-row"><span>History view</span><kbd>h</kbd></div>
       <div class="help-row"><span>Analytics view</span><kbd>a</kbd></div>
+      <div class="help-row"><span>Table view</span><kbd>t</kbd></div>
+      <div class="help-row"><span>Expand subagents</span><kbd>→</kbd></div>
+      <div class="help-row"><span>Collapse subagents</span><kbd>←</kbd></div>
+      <div class="help-row"><span>Replay: play / pause</span><kbd>Space</kbd></div>
+      <div class="help-row"><span>Replay: restart</span><kbd>R</kbd></div>
       <div class="help-row"><span>Help</span><kbd>?</kbd></div>
     </div>
   `;

--- a/web/src/components/session-list.ts
+++ b/web/src/components/session-list.ts
@@ -263,7 +263,7 @@ function renderList(): void {
     for (const sess of activeSorted) {
       renderCompact(sess, section);
       const children = activeChildrenOf.get(sess.id);
-      if (children && children.length > 0) {
+      if (children && children.length > 0 && !state.collapsedSubagents.has(sess.id)) {
         const familyIds = new Set([sess.id, ...children.map((c) => c.id)]);
         if (state.selectedSessionId && familyIds.has(state.selectedSessionId)) {
           // Active parents: only show active children
@@ -343,7 +343,7 @@ function renderList(): void {
       renderCompact(sess, items);
       // For inactive parents: show children inline when this family is selected
       const children = childrenOf.get(sess.id);
-      if (children && children.length > 0) {
+      if (children && children.length > 0 && !state.collapsedSubagents.has(sess.id)) {
         const familyIds = new Set([sess.id, ...children.map((c) => c.id)]);
         if (state.selectedSessionId && familyIds.has(state.selectedSessionId)) {
           for (const child of sort([...children])) renderCompact(child, items);

--- a/web/src/components/table-view.ts
+++ b/web/src/components/table-view.ts
@@ -1,0 +1,212 @@
+// web/src/components/table-view.ts
+import type { Session } from '../types';
+import { state, subscribe, update } from '../state';
+import { sessionDisplayName, formatDurationSecs } from '../utils';
+import '../styles/views.css';
+
+type SortKey = 'name' | 'status' | 'cost' | 'tokens' | 'messages' | 'errors' | 'duration' | 'lastActive';
+type SortDir = 'asc' | 'desc';
+
+let container: HTMLElement | null = null;
+let tableEl: HTMLElement | null = null;
+let sortKey: SortKey = 'lastActive';
+let sortDir: SortDir = 'desc';
+
+export function render(mount: HTMLElement): void {
+  container = mount;
+  subscribe((_s, changed) => {
+    if (
+      changed.has('view') ||
+      changed.has('sessions') ||
+      changed.has('grouped') ||
+      changed.has('selectedSessionId')
+    ) {
+      renderTable();
+    }
+  });
+  renderTable();
+}
+
+function getAllSessions(): Session[] {
+  const g = state.grouped;
+  if (!g) return [];
+  return [
+    ...g.active,
+    ...g.lastHour,
+    ...g.today,
+    ...g.yesterday,
+    ...g.thisWeek,
+    ...g.older,
+  ].filter((s) => !s.parentId); // top-level only
+}
+
+function sortSessions(sessions: Session[]): Session[] {
+  return [...sessions].sort((a, b) => {
+    let cmp = 0;
+    switch (sortKey) {
+      case 'name':
+        cmp = sessionDisplayName(a).localeCompare(sessionDisplayName(b));
+        break;
+      case 'status':
+        cmp = (a.isActive ? 0 : 1) - (b.isActive ? 0 : 1);
+        break;
+      case 'cost':
+        cmp = a.totalCost - b.totalCost;
+        break;
+      case 'tokens':
+        cmp = (a.inputTokens + a.outputTokens) - (b.inputTokens + b.outputTokens);
+        break;
+      case 'messages':
+        cmp = a.messageCount - b.messageCount;
+        break;
+      case 'errors':
+        cmp = a.errorCount - b.errorCount;
+        break;
+      case 'duration': {
+        const dA = a.startedAt ? Date.now() - new Date(a.startedAt).getTime() : 0;
+        const dB = b.startedAt ? Date.now() - new Date(b.startedAt).getTime() : 0;
+        cmp = dA - dB;
+        break;
+      }
+      case 'lastActive':
+        cmp = new Date(a.lastActive).getTime() - new Date(b.lastActive).getTime();
+        break;
+    }
+    return sortDir === 'asc' ? cmp : -cmp;
+  });
+}
+
+function handleSort(key: SortKey): void {
+  if (sortKey === key) {
+    sortDir = sortDir === 'asc' ? 'desc' : 'asc';
+  } else {
+    sortKey = key;
+    sortDir = 'desc';
+  }
+  renderTable();
+}
+
+function renderTable(): void {
+  if (!container) return;
+
+  if (state.view !== 'table') {
+    if (tableEl) {
+      tableEl.style.display = 'none';
+    }
+    return;
+  }
+
+  if (!tableEl) {
+    tableEl = document.createElement('div');
+    tableEl.className = 'table-view';
+    container.appendChild(tableEl);
+  }
+
+  tableEl.style.display = 'flex';
+  tableEl.style.flexDirection = 'column';
+
+  const sessions = sortSessions(getAllSessions());
+
+  const cols: { key: SortKey; label: string; align?: string }[] = [
+    { key: 'name', label: 'SESSION' },
+    { key: 'status', label: 'STATUS' },
+    { key: 'cost', label: 'COST', align: 'right' },
+    { key: 'tokens', label: 'TOKENS', align: 'right' },
+    { key: 'messages', label: 'MSGS', align: 'right' },
+    { key: 'errors', label: 'ERRORS', align: 'right' },
+    { key: 'duration', label: 'DURATION', align: 'right' },
+    { key: 'lastActive', label: 'LAST ACTIVE', align: 'right' },
+  ];
+
+  const arrowFor = (key: SortKey): string => {
+    if (sortKey !== key) return '<span style="color:var(--text-dim);opacity:0.4">⇅</span>';
+    return sortDir === 'asc'
+      ? '<span style="color:var(--cyan)">↑</span>'
+      : '<span style="color:var(--cyan)">↓</span>';
+  };
+
+  const headerCells = cols
+    .map(
+      (c) =>
+        `<th data-sort="${c.key}" style="text-align:${c.align ?? 'left'};cursor:pointer;user-select:none;padding:6px 10px;border-bottom:1px solid var(--border);color:var(--text-dim);font-size:10px;letter-spacing:0.5px;white-space:nowrap">
+          ${c.label} ${arrowFor(c.key)}
+        </th>`
+    )
+    .join('');
+
+  const rowsHtml = sessions
+    .map((s) => {
+      const name = sessionDisplayName(s);
+      const totalTokens = s.inputTokens + s.outputTokens;
+      const durationMs = s.startedAt ? Date.now() - new Date(s.startedAt).getTime() : 0;
+      const duration = formatDurationSecs(durationMs / 1000);
+      const lastActive = new Date(s.lastActive).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      const statusColor = s.isActive
+        ? s.status === 'thinking'
+          ? 'var(--cyan)'
+          : s.status === 'tool_use'
+            ? 'var(--yellow)'
+            : 'var(--green)'
+        : 'var(--text-dim)';
+      const statusLabel = s.isActive ? s.status.toUpperCase().replace('_', ' ') : 'IDLE';
+      const isSelected = state.selectedSessionId === s.id;
+
+      return `<tr data-session-id="${s.id}" style="cursor:pointer;background:${isSelected ? 'var(--bg-hover)' : 'transparent'};border-left:${isSelected ? '2px solid var(--cyan)' : '2px solid transparent'}">
+        <td style="padding:5px 10px;font-size:11px;max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${name}">${name}</td>
+        <td style="padding:5px 10px;font-size:10px;color:${statusColor}">${statusLabel}</td>
+        <td style="padding:5px 10px;font-size:11px;text-align:right;color:${s.totalCost > 0.1 ? 'var(--yellow)' : 'var(--text)'}">$${s.totalCost.toFixed(4)}</td>
+        <td style="padding:5px 10px;font-size:11px;text-align:right;color:var(--text-dim)">${totalTokens.toLocaleString()}</td>
+        <td style="padding:5px 10px;font-size:11px;text-align:right">${s.messageCount}</td>
+        <td style="padding:5px 10px;font-size:11px;text-align:right;color:${s.errorCount > 0 ? 'var(--red)' : 'var(--text-dim)'}">${s.errorCount || '—'}</td>
+        <td style="padding:5px 10px;font-size:11px;text-align:right;color:var(--text-dim)">${duration}</td>
+        <td style="padding:5px 10px;font-size:11px;text-align:right;color:var(--text-dim)">${lastActive}</td>
+      </tr>`;
+    })
+    .join('');
+
+  tableEl.innerHTML = `
+    <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 10px;border-bottom:1px solid var(--border)">
+      <span style="color:var(--cyan);font-size:11px;letter-spacing:1px">TABLE VIEW</span>
+      <span style="color:var(--text-dim);font-size:10px">${sessions.length} session${sessions.length !== 1 ? 's' : ''}</span>
+    </div>
+    <div style="overflow:auto;flex:1">
+      <table style="width:100%;border-collapse:collapse;font-family:var(--font-mono,monospace)">
+        <thead>
+          <tr>${headerCells}</tr>
+        </thead>
+        <tbody>${rowsHtml}</tbody>
+      </table>
+    </div>
+  `;
+
+  // Sort header click handlers
+  tableEl.querySelectorAll<HTMLElement>('th[data-sort]').forEach((th) => {
+    th.addEventListener('click', () => handleSort(th.dataset.sort as SortKey));
+    th.addEventListener('mouseenter', () => { th.style.color = 'var(--text)'; });
+    th.addEventListener('mouseleave', () => { th.style.color = sortKey === th.dataset.sort ? 'var(--cyan)' : 'var(--text-dim)'; });
+  });
+
+  // Row click: select session
+  tableEl.querySelectorAll<HTMLElement>('tr[data-session-id]').forEach((row) => {
+    row.addEventListener('mouseenter', () => {
+      if (state.selectedSessionId !== row.dataset.sessionId) {
+        row.style.background = 'var(--bg-hover)';
+      }
+    });
+    row.addEventListener('mouseleave', () => {
+      if (state.selectedSessionId !== row.dataset.sessionId) {
+        row.style.background = 'transparent';
+      }
+    });
+    row.addEventListener('click', () => {
+      const sid = row.dataset.sessionId!;
+      update({
+        selectedSessionId: state.selectedSessionId === sid ? null : sid,
+        view: 'list',
+      });
+    });
+  });
+}

--- a/web/src/hash.ts
+++ b/web/src/hash.ts
@@ -37,7 +37,7 @@ function restoreFromHash(): void {
   const session = params.get('session');
   if (session) changes.selectedSessionId = session;
   const view = params.get('view');
-  if (view && ['list', 'graph', 'history', 'analytics', 'timeline'].includes(view)) {
+  if (view && ['list', 'graph', 'history', 'analytics', 'timeline', 'table'].includes(view)) {
     changes.view = view;
   }
   if (Object.keys(changes).length > 0) {

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -10,6 +10,8 @@ import { render as renderGraphView } from './components/graph-view';
 import { render as renderHistoryView } from './components/history-view';
 import { render as renderTimeline } from './components/timeline-view';
 import { render as renderAnalyticsView } from './components/analytics-view';
+import { render as renderTableView } from './components/table-view';
+import { render as renderReplay, togglePlay as replayTogglePlay, restart as replayRestart } from './components/replay';
 import { render as renderBudget } from './components/budget-popover';
 import { toggle as toggleHelp } from './components/help-overlay';
 import { dismiss as dismissCostBreakdown } from './components/cost-breakdown';
@@ -34,6 +36,8 @@ renderGraphView(feedMount);
 renderHistoryView(feedMount);
 renderTimeline(feedMount);
 renderAnalyticsView(feedMount);
+renderTableView(feedMount);
+renderReplay(feedMount);
 
 // Search dropdown
 const searchBox = topbarMount.querySelector<HTMLElement>('.search-box');
@@ -93,6 +97,23 @@ document.addEventListener('keydown', (e) => {
     case 'a':
       update({ view: state.view === 'analytics' ? 'list' : 'analytics' });
       break;
+    case 't':
+      update({ view: state.view === 'table' ? 'list' : 'table' });
+      break;
+    case ' ': {
+      if (state.replaySessionId) {
+        e.preventDefault();
+        replayTogglePlay();
+      }
+      break;
+    }
+    case 'r':
+    case 'R': {
+      if (state.replaySessionId) {
+        replayRestart();
+      }
+      break;
+    }
     case '?':
       toggleHelp();
       break;
@@ -132,16 +153,32 @@ document.addEventListener('keydown', (e) => {
     }
     case 'ArrowRight': {
       if (state.focusedSessionId) {
-        update({ selectedSessionId: state.focusedSessionId });
+        const focused = state.sessions.get(state.focusedSessionId);
+        if (focused && (focused.children ?? []).length > 0) {
+          // Expand subagents: remove from collapsed set
+          const next = new Set(state.collapsedSubagents);
+          next.delete(state.focusedSessionId);
+          update({ collapsedSubagents: next });
+        } else {
+          update({ selectedSessionId: state.focusedSessionId });
+        }
       }
       break;
     }
     case 'ArrowLeft': {
       if (state.focusedSessionId) {
-        update({
-          selectedSessionId:
-            state.selectedSessionId === state.focusedSessionId ? null : state.focusedSessionId,
-        });
+        const focused = state.sessions.get(state.focusedSessionId);
+        if (focused && (focused.children ?? []).length > 0) {
+          // Collapse subagents: add to collapsed set
+          const next = new Set(state.collapsedSubagents);
+          next.add(state.focusedSessionId);
+          update({ collapsedSubagents: next });
+        } else {
+          update({
+            selectedSessionId:
+              state.selectedSessionId === state.focusedSessionId ? null : state.focusedSessionId,
+          });
+        }
       }
       break;
     }

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -5,7 +5,7 @@ export interface AppState {
   sessions: Map<string, Session>;
   grouped: GroupedSessions | null;
   selectedSessionId: string | null;
-  view: 'list' | 'graph' | 'history' | 'analytics' | 'timeline';
+  view: 'list' | 'graph' | 'history' | 'analytics' | 'timeline' | 'table';
   repoFilter: string | null;
   searchQuery: string;
   searchResults: Event[];
@@ -47,6 +47,9 @@ export interface AppState {
 
   // Sidebar
   sidebarCollapsed: boolean;
+
+  // Per-session subagent collapse (set of parent session IDs whose children are hidden)
+  collapsedSubagents: Set<string>;
 }
 
 type Listener = (state: AppState, changedKeys: Set<string>) => void;
@@ -91,6 +94,7 @@ export const state: AppState = {
   stats: null,
   statsWindow: (localStorage.getItem('claude-monitor-stats-window') as StatsWindow) || 'today',
   sidebarCollapsed: false,
+  collapsedSubagents: new Set<string>(),
 };
 
 export function subscribe(listener: Listener): () => void {


### PR DESCRIPTION
## Summary

Addresses both open bugs:

- **#197** — `install.sh` fails on M1 Mac because the CI workflow packs tarballs with the binary named `claude-monitor` (for Homebrew compatibility) but the script tried to `mv` the platform-specific name. Added fallback that checks for `claude-monitor` first, then `claude-monitor-OS-ARCH`.

- **#168** — Four missing features now implemented:
  - **Table view** — new `table-view.ts` component, sortable by cost/tokens/messages/errors/duration/last-active. Bound to `t` key, `#view=table` hash, mounted in `feed-mount`
  - **Replay UI** — `replay.render()` now called in `main.ts`; REPLAY button added to feed-panel header next to TIMELINE; `Space` toggles play/pause, `R` restarts
  - **Arrow key fix** — `← →` now collapse/expand subagent children when the focused session has children (new `collapsedSubagents: Set<string>` in state); falls back to select/deselect for leaf sessions
  - **Help overlay** — updated with all new shortcuts (`t`, `←`, `→`, `Space`, `R`)

## Test plan

- [ ] `curl -fsSL https://raw.githubusercontent.com/Zxela/claude-monitor/main/install.sh | sh` succeeds on M1 Mac
- [ ] `t` key toggles table view; columns are sortable; clicking a row selects the session and returns to list view
- [ ] With a session selected: REPLAY button appears in feed header, opens replay panel; Space/R work
- [ ] With a session that has subagents focused: `→` shows children, `←` hides them
- [ ] `?` help overlay shows all new shortcuts

Closes #197
Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)