### PR TITLE
feat: deep dive fixes — combined search, configurable preview length

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -563,6 +563,7 @@ paths:
                 example:
                   retention_hot_days: "30"
                   retention_warm_days: "90"
+                  preview_max_length: "200"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -570,7 +571,10 @@ paths:
     put:
       tags: [settings]
       summary: Update a setting
-      description: Sets a single setting by key. Creates the key if it does not exist.
+      description: >
+        Sets a single setting by key. Creates the key if it does not exist.
+        Valid keys: `retention_hot_days`, `retention_warm_days`,
+        `preview_max_length` (integer 50–2000; controls content preview truncation length).
       operationId: updateSetting
       parameters:
         - name: key

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -503,6 +503,48 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/search/combined:
+    get:
+      tags: [search]
+      summary: Combined FTS5 + full-content search
+      description: >
+        Runs FTS5 search first (fast, indexes the 200-character content preview).
+        If fewer than 10 results are returned, also runs a full-content substring
+        scan (slower, searches the complete stored text) and merges both result
+        sets, deduplicating by event ID. The response includes a `meta.searchedFull`
+        boolean that is `true` when the full-content scan was also executed.
+
+        Use this endpoint instead of calling `/api/search` and `/api/search/full`
+        separately — it avoids a redundant round trip for queries that already
+        produce sufficient FTS5 results.
+      operationId: searchCombined
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query string.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: >
+            Maximum number of results to return per search method. Clamped to 1–200.
+            Defaults to 50.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+            default: 50
+      responses:
+        "200":
+          description: Combined search result with meta flag
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CombinedSearchResponse"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /api/settings:
     get:
       tags: [settings]
@@ -1570,6 +1612,34 @@ components:
           format: int64
           description: Total number of event rows in the database.
           example: 150000
+
+    CombinedSearchResponse:
+      type: object
+      description: >
+        Response from /api/search/combined. Contains merged results from FTS5
+        and (conditionally) full-content search, plus metadata indicating
+        whether the slower full-content scan was executed.
+      required: [results, meta]
+      properties:
+        results:
+          type: array
+          description: >
+            Deduplicated event rows from FTS5 search and, when fewer than 10 FTS5
+            results were found, also from the full-content scan.
+          items:
+            $ref: "#/components/schemas/EventRow"
+        meta:
+          type: object
+          required: [searchedFull]
+          description: Metadata about which search strategies were used.
+          properties:
+            searchedFull:
+              type: boolean
+              description: >
+                True when the full-content scan was also run (i.e., FTS5 returned
+                fewer than 10 results). False when FTS5 alone provided sufficient
+                results.
+              example: false
 
     BroadcastEvent:
       type: object

--- a/cmd/claude-monitor/handlers.go
+++ b/cmd/claude-monitor/handlers.go
@@ -395,6 +395,64 @@ func handleSearchFull(historyDB *store.DB) http.HandlerFunc {
 	}
 }
 
+// handleSearchCombined serves GET /api/search/combined.
+// It runs FTS5 first; if fewer than 10 results are returned, it also runs a
+// full-content scan, merges the two result sets (deduplicating by event ID),
+// and returns a wrapper with a meta.searchedFull boolean so callers can tell
+// whether the slower path was exercised.
+func handleSearchCombined(historyDB *store.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("q")
+		if query == "" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"results":[],"meta":{"searchedFull":false}}`))
+			return
+		}
+		limit := defaultPageLimit
+		if n, err := strconv.Atoi(r.URL.Query().Get("limit")); err == nil && n > 0 && n <= 200 {
+			limit = n
+		}
+
+		ftsResults, err := historyDB.SearchFTS(query, limit)
+		if err != nil {
+			log.Printf("combined search FTS error: %v", err)
+			writeJSONError(w, "search failed", http.StatusInternalServerError)
+			return
+		}
+		if ftsResults == nil {
+			ftsResults = []store.EventRow{}
+		}
+
+		searchedFull := false
+		if len(ftsResults) < 10 {
+			fullResults, err := historyDB.SearchFullContent(query, limit)
+			if err != nil {
+				log.Printf("combined search full error: %v", err)
+				writeJSONError(w, "search failed", http.StatusInternalServerError)
+				return
+			}
+			searchedFull = true
+
+			// Merge, deduplicating by event ID.
+			seen := make(map[int64]bool, len(ftsResults))
+			for _, r := range ftsResults {
+				seen[r.ID] = true
+			}
+			for _, r := range fullResults {
+				if !seen[r.ID] {
+					seen[r.ID] = true
+					ftsResults = append(ftsResults, r)
+				}
+			}
+		}
+
+		writeJSON(w, map[string]any{
+			"results": ftsResults,
+			"meta":    map[string]bool{"searchedFull": searchedFull},
+		})
+	}
+}
+
 // handleSessionEvents serves GET /api/sessions/{id}/events.
 func handleSessionEvents(historyDB *store.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/claude-monitor/handlers.go
+++ b/cmd/claude-monitor/handlers.go
@@ -557,6 +557,7 @@ func handleSettings(historyDB *store.DB) http.HandlerFunc {
 var validSettingKeys = map[string]bool{
 	"retention_hot_days":  true,
 	"retention_warm_days": true,
+	"preview_max_length":  true,
 }
 
 // handleSettingsUpdate serves PUT /api/settings/{key}.
@@ -575,9 +576,23 @@ func handleSettingsUpdate(historyDB *store.DB) http.HandlerFunc {
 			writeJSONError(w, "invalid request body", http.StatusBadRequest)
 			return
 		}
+		// Key-specific validation.
+		if key == "preview_max_length" {
+			n, err := strconv.Atoi(body.Value)
+			if err != nil || n < 50 || n > 2000 {
+				writeJSONError(w, "preview_max_length must be an integer between 50 and 2000", http.StatusBadRequest)
+				return
+			}
+		}
 		if err := historyDB.SetSetting(key, body.Value); err != nil {
 			writeJSONError(w, "failed to update setting", http.StatusInternalServerError)
 			return
+		}
+		// Apply preview_max_length live so new parses use the updated value immediately.
+		if key == "preview_max_length" {
+			if n, err := strconv.Atoi(body.Value); err == nil {
+				parser.SetPreviewMaxLength(n)
+			}
 		}
 		writeJSON(w, map[string]bool{"ok": true})
 	}

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -566,6 +566,7 @@ Examples:
 	mux.HandleFunc("GET /api/repos/{id}/sessions", handleRepoSessions(historyDB))
 	mux.HandleFunc("GET /api/search", handleSearch(historyDB))
 	mux.HandleFunc("GET /api/search/full", handleSearchFull(historyDB))
+	mux.HandleFunc("GET /api/search/combined", handleSearchCombined(historyDB))
 	mux.HandleFunc("GET /api/sessions/{id}/events", handleSessionEvents(historyDB))
 	mux.HandleFunc("GET /api/sessions/{id}/replay", handleSessionReplay(historyDB))
 	mux.HandleFunc("GET /api/settings", handleSettings(historyDB))

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -360,6 +360,14 @@ Examples:
 		log.Printf("loaded model pricing entries from DB")
 	}
 
+	// Load preview_max_length setting and apply to parser.
+	if v, err := historyDB.GetSetting("preview_max_length"); err == nil {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			parser.SetPreviewMaxLength(n)
+			log.Printf("preview_max_length set to %d", n)
+		}
+	}
+
 	// Repo resolver with persisted cwd→repo cache.
 	resolver := repo.NewResolver()
 	if cached, err := historyDB.LoadCwdRepos(); err == nil {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -15,6 +15,20 @@ import (
 
 const maxContentPreview = 200
 
+// previewMaxLength is the runtime-configurable preview truncation limit.
+// Default matches maxContentPreview. Updated via SetPreviewMaxLength.
+var previewMaxLength atomic.Int64
+
+func init() {
+	previewMaxLength.Store(maxContentPreview)
+}
+
+// SetPreviewMaxLength updates the content preview truncation length at runtime.
+// Safe to call concurrently; takes effect on the next parse.
+func SetPreviewMaxLength(n int) {
+	previewMaxLength.Store(int64(n))
+}
+
 // rawMessage mirrors the on-disk JSONL structure. Content can be a string or
 // an array of content blocks, so we capture it as raw JSON for flexible decoding.
 type rawMessage struct {
@@ -326,8 +340,9 @@ func buildBaseEvent(raw *rawMessage) *Event {
 	if raw.Type == "summary" {
 		msg.Subtype = "compact"
 		if raw.Summary != "" {
-			msg.ContentText = truncate(raw.Summary, maxContentPreview)
-			if len([]rune(raw.Summary)) > maxContentPreview {
+			limit := int(previewMaxLength.Load())
+			msg.ContentText = truncate(raw.Summary, limit)
+			if len([]rune(raw.Summary)) > limit {
 				msg.FullContent = raw.Summary
 			}
 		} else {
@@ -496,10 +511,11 @@ func extractContent(raw json.RawMessage) contentInfo {
 	// Try plain string.
 	var s string
 	if err := json.Unmarshal(raw, &s); err == nil {
-		if len([]rune(s)) <= maxContentPreview {
+		limit := int(previewMaxLength.Load())
+		if len([]rune(s)) <= limit {
 			return contentInfo{text: s}
 		}
-		return contentInfo{text: truncate(s, maxContentPreview), fullText: s}
+		return contentInfo{text: truncate(s, limit), fullText: s}
 	}
 
 	// Try array of content blocks.
@@ -514,8 +530,9 @@ func extractContent(raw json.RawMessage) contentInfo {
 		switch b.Type {
 		case "text":
 			if b.Text != "" && info.text == "" {
-				info.text = truncate(b.Text, maxContentPreview)
-				if len([]rune(b.Text)) > maxContentPreview {
+				limit := int(previewMaxLength.Load())
+				info.text = truncate(b.Text, limit)
+				if len([]rune(b.Text)) > limit {
 					info.fullText = b.Text
 				}
 			}
@@ -609,8 +626,9 @@ func extractContent(raw json.RawMessage) contentInfo {
 					resultText = b.Text
 				}
 				if resultText != "" {
-					info.text = truncate(resultText, maxContentPreview)
-					if len([]rune(resultText)) > maxContentPreview {
+					limit := int(previewMaxLength.Load())
+					info.text = truncate(resultText, limit)
+					if len([]rune(resultText)) > limit {
 						info.fullText = resultText
 					}
 				} else {

--- a/internal/store/migrations/012_preview_max_length.go
+++ b/internal/store/migrations/012_preview_max_length.go
@@ -1,0 +1,17 @@
+package migrations
+
+import "database/sql"
+
+func init() {
+	Register(12, Migration{
+		Name: "preview_max_length",
+		Up: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`INSERT OR IGNORE INTO settings VALUES ('preview_max_length', '200')`)
+			return err
+		},
+		Down: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`DELETE FROM settings WHERE key = 'preview_max_length'`)
+			return err
+		},
+	})
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -32,6 +32,20 @@ export async function fetchFullSearch(query: string, limit = 50): Promise<Event[
   return request<Event[]>(`/api/search/full?q=${encodeURIComponent(query)}&limit=${limit}`);
 }
 
+export interface CombinedSearchResult {
+  results: Event[];
+  meta: { searchedFull: boolean };
+}
+
+export async function fetchSearchCombined(
+  query: string,
+  limit = 50,
+): Promise<CombinedSearchResult> {
+  return request<CombinedSearchResult>(
+    `/api/search/combined?q=${encodeURIComponent(query)}&limit=${limit}`,
+  );
+}
+
 export async function fetchSessionEvents(sessionId: string, last?: number): Promise<Event[]> {
   const params = last ? `?last=${last}` : '';
   return request<Event[]>(`/api/sessions/${sessionId}/events${params}`);

--- a/web/src/components/search.ts
+++ b/web/src/components/search.ts
@@ -1,7 +1,7 @@
 import type { Event } from '../types';
 import { state, subscribe, update } from '../state';
 import type { AppState } from '../state';
-import { fetchSearch } from '../api';
+import { fetchSearchCombined } from '../api';
 import { escapeHtml } from '../utils';
 import '../styles/feed.css';
 
@@ -40,16 +40,21 @@ function onStateChange(_state: AppState, changed: Set<string>): void {
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(async () => {
       try {
-        const results = await fetchSearch(state.searchQuery);
-        update({ searchResults: results, searchLoading: false, searchError: false });
+        const { results, meta } = await fetchSearchCombined(state.searchQuery);
+        update({
+          searchResults: results,
+          searchLoading: false,
+          searchError: false,
+          searchedFull: meta.searchedFull,
+        });
       } catch (err) {
         console.error('Search failed:', err);
-        update({ searchResults: [], searchLoading: false, searchError: true });
+        update({ searchResults: [], searchLoading: false, searchError: true, searchedFull: false });
       }
     }, 300);
   }
 
-  if (changed.has('searchResults') || changed.has('searchLoading')) {
+  if (changed.has('searchResults') || changed.has('searchLoading') || changed.has('searchedFull')) {
     renderResults();
   }
 
@@ -80,7 +85,8 @@ function renderResults(): void {
   }
 
   if (state.searchResults.length === 0 && state.searchQuery.length > 0) {
-    dropdown.innerHTML = `<div class="search-status">No results for "${escapeHtml(state.searchQuery)}"</div>`;
+    const fullScanNote = state.searchedFull ? ' (full scan)' : '';
+    dropdown.innerHTML = `<div class="search-status">No results for "${escapeHtml(state.searchQuery)}"${escapeHtml(fullScanNote)}</div>`;
     return;
   }
 
@@ -98,6 +104,15 @@ function renderResults(): void {
   }
 
   dropdown.innerHTML = '';
+
+  if (state.searchedFull) {
+    const indicator = document.createElement('div');
+    indicator.className = 'search-status search-full-scan-note';
+    const count = state.searchResults.length;
+    indicator.textContent = `${count} result${count !== 1 ? 's' : ''} (full scan)`;
+    dropdown.appendChild(indicator);
+  }
+
   for (const [sessionId, group] of groups) {
     const visibleResults = group.results.slice(0, 3);
     const remaining = group.results.length - visibleResults.length;

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -12,6 +12,7 @@ export interface AppState {
   searchLoading: boolean;
   searchError: boolean;
   searchOpen: boolean;
+  searchedFull: boolean;
   searchHighlightEventId: number | null;
   connected: boolean;
   eventCount: number;
@@ -67,6 +68,7 @@ export const state: AppState = {
   searchLoading: false,
   searchError: false,
   searchOpen: false,
+  searchedFull: false,
   searchHighlightEventId: null,
   connected: false,
   eventCount: 0,


### PR DESCRIPTION
## Summary

Two remaining features from the deep-dive analysis, on top of the fixes already merged in v3.2.0 (pricing table, dropped events, thinking content, error detection, parentUuid linking, budget windows).

- **Combined search endpoint** (`GET /api/search/combined`) — runs FTS5 first, falls back to full content scan if fewer than 10 results. Frontend updated to use it. Shows "(full scan)" indicator in results. Eliminates the need for users to know when to use `/api/search` vs `/api/search/full`.

- **Configurable content preview length** — `maxContentPreview` was hardcoded at 200 runes, truncating long Bash commands. Now persisted in SQLite settings (`preview_max_length`), loaded at startup, live-updatable via `PUT /api/settings/preview_max_length` (valid range: 50–2000). Backed by `atomic.Int64` for safe concurrent reads.

## What's already in main (v3.2.0)
The other 6 fixes from the deep-dive landed in PR #200:
- Dynamic pricing table (SQLite-backed, live-updatable, warn-on-unknown-model)
- Dropped events surfaced in UI (WebSocket broadcast + dismissible banner)
- Extended thinking content captured and displayed
- Heuristic error detection narrowed (false positive fix)
- parentUuid used for subagent session linking (with deferred resolution)
- Session-spanning budget windows (today/week/month/all)

## Test plan
- [ ] `GET /api/search/combined?q=foo` returns results with `meta.searchedFull` boolean
- [ ] Search UI shows "(full scan)" when full scan was run
- [ ] `PUT /api/settings/preview_max_length` with value `500` updates live; subsequent events use 500-rune previews
- [ ] Value below 50 or above 2000 returns HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)