### PR TITLE
fix: handle all toolUseResult shapes — string, array, and object

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -370,15 +370,43 @@ func applySystemMetadata(msg *Event, raw *rawMessage) {
 }
 
 // applyToolResultMetadata extracts metadata from the toolUseResult JSON field
-// found on user/tool_result lines.
+// found on user/tool_result lines. The field can be one of three shapes:
+//   - object {"durationMs":…} — full metadata, extract all fields
+//   - string "raw output"     — plain text output, use as content preview fallback
+//   - array  […]              — content blocks, extract text from each block
 func applyToolResultMetadata(msg *Event, raw *rawMessage) {
 	if len(raw.ToolUseResult) == 0 {
 		return
 	}
-	// toolUseResult can be a plain string or array rather than the expected
-	// metadata object — skip any non-object value gracefully.
-	first := raw.ToolUseResult[0]
-	if first != '{' {
+	switch raw.ToolUseResult[0] {
+	case '"':
+		// Plain string: raw tool output text. Use as content preview if not already set.
+		var s string
+		if err := json.Unmarshal(raw.ToolUseResult, &s); err == nil && msg.ContentText == "" {
+			msg.ContentText = truncate(s, int(previewMaxLength.Load()))
+			if len([]rune(s)) > int(previewMaxLength.Load()) {
+				msg.FullContent = s
+			}
+		}
+		return
+	case '[':
+		// Array of content blocks: extract text from each block.
+		var blocks []contentBlock
+		if err := json.Unmarshal(raw.ToolUseResult, &blocks); err == nil && msg.ContentText == "" {
+			for _, b := range blocks {
+				if b.Type == "text" && b.Text != "" {
+					msg.ContentText = truncate(b.Text, int(previewMaxLength.Load()))
+					if len([]rune(b.Text)) > int(previewMaxLength.Load()) {
+						msg.FullContent = b.Text
+					}
+					break
+				}
+			}
+		}
+		return
+	case '{':
+		// Object: full metadata struct — fall through to unmarshal below.
+	default:
 		return
 	}
 	var tr rawToolResult

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -375,9 +375,10 @@ func applyToolResultMetadata(msg *Event, raw *rawMessage) {
 	if len(raw.ToolUseResult) == 0 {
 		return
 	}
-	// toolUseResult is sometimes a plain string (e.g. tool output text) rather
-	// than a structured metadata object. Detect and skip gracefully.
-	if len(raw.ToolUseResult) > 0 && raw.ToolUseResult[0] == '"' {
+	// toolUseResult can be a plain string or array rather than the expected
+	// metadata object — skip any non-object value gracefully.
+	first := raw.ToolUseResult[0]
+	if first != '{' {
 		return
 	}
 	var tr rawToolResult


### PR DESCRIPTION
## Summary

- Claude's JSONL now emits `toolUseResult` as a plain string or array in addition to the original object shape, causing `cannot unmarshal string/array into Go value of type parser.rawToolResult` errors on startup.
- First commit skipped non-object values (stops the crash).
- Second commit properly parses each shape:
  - **Object `{…}`** — existing behavior, extracts duration/tokens/success/stderr metadata
  - **String `"…"`** — raw text output, used as content preview if not already set
  - **Array `[…]`** — content blocks, extracts text from the first text block as content preview

## Test plan
- [ ] No unmarshal errors when running against a live `~/.claude/projects/` directory
- [ ] Events with string `toolUseResult` show content in the feed
- [ ] Events with array `toolUseResult` show content in the feed
- [ ] All tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)