### PR TITLE
fix: add missing model pricing for Opus 4.5/4.7, suppress synthetic warning

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -187,7 +187,9 @@ type modelPricing struct {
 
 // pricingTable is the compile-time fallback used when the DB is empty or unavailable.
 var pricingTable = map[string]modelPricing{
+	"claude-opus-4-7":   {5.0, 25.0, 0.50, 6.25},
 	"claude-opus-4-6":   {5.0, 25.0, 0.50, 6.25},
+	"claude-opus-4-5":   {5.0, 25.0, 0.50, 6.25},
 	"claude-sonnet-4-6": {3.0, 15.0, 0.30, 3.75},
 	"claude-haiku-4-5":  {1.0, 5.0, 0.10, 1.25},
 }
@@ -262,8 +264,9 @@ func lookupPricing(model string) (modelPricing, bool) {
 
 func computeCost(model string, usage rawUsage) float64 {
 	p, found := lookupPricing(model)
-	if !found && model != "" {
+	if !found && model != "" && model != "<synthetic>" {
 		// Warn once per unknown model per process run.
+		// "<synthetic>" is an internal Claude Code model string; suppress its warning.
 		if _, alreadyWarned := warnedModels.LoadOrStore(model, true); !alreadyWarned {
 			log.Printf("[WARN] unknown model pricing for %q, using Sonnet default", model)
 		}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -476,8 +476,8 @@ func TestParseLine_RealWorldSample(t *testing.T) {
 	if msg.CacheReadTokens != 128 {
 		t.Errorf("CacheReadTokens: got %d, want 128", msg.CacheReadTokens)
 	}
-	// Cost computed from tokens: 512*3/1e6 + 64*15/1e6 + 128*0.30/1e6
-	expectedCost := float64(512)*3.0/1e6 + float64(64)*15.0/1e6 + float64(128)*0.30/1e6
+	// Cost computed from tokens using claude-opus-4-5 pricing (5.0/25.0/0.50 per MTok)
+	expectedCost := float64(512)*5.0/1e6 + float64(64)*25.0/1e6 + float64(128)*0.50/1e6
 	if math.Abs(msg.CostUSD-expectedCost) > 1e-12 {
 		t.Errorf("CostUSD: got %g, want %g", msg.CostUSD, expectedCost)
 	}


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-5` and `claude-opus-4-7` to pricing table ($5/$25/MTok — same as 4.6)
- Prefix matching already handles dated variants like `claude-opus-4-5-20251101` automatically
- Suppress `[WARN]` for `<synthetic>` model — it's an internal Claude Code model string, not a real billable model
- Fix test expected cost for `claude-opus-4-5` to use Opus pricing (was accidentally using Sonnet rates before this entry existed)

Fixes the three warnings from the issue:
```
[WARN] unknown model pricing for "<synthetic>", using Sonnet default
[WARN] unknown model pricing for "claude-opus-4-5-20251101", using Sonnet default
[WARN] unknown model pricing for "claude-opus-4-7...", using Sonnet default
```

## Test plan
- [ ] All tests pass (`go test ./...`)
- [ ] No warnings for `<synthetic>`, `claude-opus-4-5-20251101`, or `claude-opus-4-7` variants