### PR TITLE
fix: add pull-requests: write to build-binaries job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
   build-binaries:
     permissions:
       contents: write
+      pull-requests: write
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Root cause

`gh pr create` in the `Update Homebrew formula` step was failing with:

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

The `build-binaries` job only had `permissions: contents: write`. Creating a pull request via the GitHub API also requires `pull-requests: write`.

## Fix

Add `pull-requests: write` to the job's permissions block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)