### PR TITLE
fix: topbar live/windowed clarity + history session/project split

### DIFF
--- a/web/src/components/history-view.ts
+++ b/web/src/components/history-view.ts
@@ -3,13 +3,21 @@ import type { Session } from '../types';
 import type { AppState } from '../state';
 import { state, subscribe, update } from '../state';
 import { fetchSessions } from '../api';
-import {
-  formatDurationSecs,
-  formatTokens,
-  sessionDisplayName,
-  effectiveInputTokens,
-} from '../utils';
+import { formatDurationSecs, formatTokens, effectiveInputTokens } from '../utils';
 import '../styles/views.css';
+
+function sessionIdentifier(s: Session): string {
+  if (s.sessionName) return s.sessionName;
+  return s.id.slice(0, 8);
+}
+
+function projectLabel(s: Session): string {
+  if (s.cwd) {
+    const parts = s.cwd.replace(/\/+$/, '').split('/');
+    return parts[parts.length - 1] || s.cwd;
+  }
+  return s.repoId || '';
+}
 
 let container: HTMLElement | null = null;
 let data: Session[] = [];
@@ -26,7 +34,8 @@ const COLUMNS: Column[] = [
     cls: 'col-dim',
     fmt: (r) => (r.lastActive ? new Date(r.lastActive).toLocaleString() : ''),
   },
-  { key: 'projectName', label: 'Name', fmt: (r) => sessionDisplayName(r) },
+  { key: 'session', label: 'Session', fmt: sessionIdentifier },
+  { key: 'project', label: 'Project', cls: 'col-dim', fmt: projectLabel },
   { key: 'totalCost', label: 'Cost', cls: 'col-cost', fmt: (r) => `$${r.totalCost.toFixed(2)}` },
   {
     key: 'duration',
@@ -340,7 +349,8 @@ function createRow(row: Session, isChild: boolean): HTMLTableRowElement {
     const td = document.createElement('td');
     td.textContent = col.fmt(row);
     if (col.cls) td.className = col.cls;
-    if (col.key === 'projectName') td.title = row.taskDescription || '';
+    if (col.key === 'session') td.title = row.taskDescription || '';
+    if (col.key === 'project') td.title = row.repoId || row.cwd || '';
     tr.appendChild(td);
   }
   tr.setAttribute('tabindex', '0');
@@ -367,9 +377,13 @@ function sortData(rows: Session[]): Session[] {
         va = a.inputTokens + a.outputTokens + a.cacheReadTokens + (a.cacheCreationTokens || 0);
         vb = b.inputTokens + b.outputTokens + b.cacheReadTokens + (b.cacheCreationTokens || 0);
         break;
-      case 'projectName':
-        va = sessionDisplayName(a).toLowerCase();
-        vb = sessionDisplayName(b).toLowerCase();
+      case 'session':
+        va = sessionIdentifier(a).toLowerCase();
+        vb = sessionIdentifier(b).toLowerCase();
+        break;
+      case 'project':
+        va = projectLabel(a).toLowerCase();
+        vb = projectLabel(b).toLowerCase();
         break;
       case 'model':
         va = a.model || '';

--- a/web/src/components/topbar.ts
+++ b/web/src/components/topbar.ts
@@ -29,17 +29,17 @@ export function render(container: HTMLElement): void {
       <span class="brand-diamond">◆</span>
       CLAUDE MONITOR
     </div>
-    <div class="topbar-stat"><span>ACTIVE</span> <span class="val green" data-stat="active">0</span></div>
-    <div class="topbar-stat" title="Total cost across all sessions"><span>TOTAL SPEND</span> <span class="budget-gear" role="button" tabindex="0" aria-label="Open budget and notification settings">⚙</span> <span class="val yellow" data-stat="cost">$0</span>
-      <div class="window-toggle">
+    <div class="topbar-stat" data-scope="live" title="Active sessions right now — always live, not affected by the window filter"><span class="live-dot" aria-hidden="true"></span><span>ACTIVE</span> <span class="val green" data-stat="active">0</span></div>
+    <div class="topbar-stat" data-scope="windowed" title="Total cost — filtered by the window toggle below (today / week / month / all)"><span>TOTAL SPEND</span> <span class="budget-gear" role="button" tabindex="0" aria-label="Open budget and notification settings">⚙</span> <span class="val yellow" data-stat="cost">$0</span>
+      <div class="window-toggle" title="Filters TOTAL SPEND and CACHE HIT">
         <button class="win-btn" data-window="today">TODAY</button>
         <button class="win-btn" data-window="week">WEEK</button>
         <button class="win-btn" data-window="month">MONTH</button>
         <button class="win-btn" data-window="all">ALL</button>
       </div>
     </div>
-    <div class="topbar-stat" title="Weighted cache read percentage across all sessions"><span>CACHE HIT</span> <span class="val" data-stat="cache" style="color:var(--purple)">—</span></div>
-    <div class="topbar-stat rate-stat" title="Aggregate cost velocity across all active sessions"><span>$/MIN</span> <span class="val yellow" data-stat="rate">—</span></div>
+    <div class="topbar-stat" data-scope="windowed" title="Weighted cache read percentage — filtered by the window toggle"><span>CACHE HIT</span> <span class="val" data-stat="cache" style="color:var(--purple)">—</span></div>
+    <div class="topbar-stat rate-stat" data-scope="live" title="Aggregate cost velocity across currently-active sessions — always live, not affected by the window filter"><span class="live-dot" aria-hidden="true"></span><span>$/MIN</span> <span class="val yellow" data-stat="rate">—</span></div>
     <div class="search-box">
       <input type="text" placeholder="Search all sessions..." data-search aria-label="Search sessions" />
     </div>

--- a/web/src/styles/topbar.css
+++ b/web/src/styles/topbar.css
@@ -90,6 +90,22 @@
   font-size: 12px;
 }
 
+.live-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 4px var(--green);
+  animation: livePulse 2s ease-in-out infinite;
+  flex-shrink: 0;
+}
+
+@keyframes livePulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
 .cost-window-label {
   font-size: 9px;
   font-weight: 400;


### PR DESCRIPTION
## Summary
- Topbar: decouple live stats (ACTIVE, \$/MIN) from windowed stats (TOTAL SPEND, CACHE HIT) with a pulsing green live-dot and clarified tooltips. The window toggle below TOTAL SPEND now visibly scopes only to the two windowed stats.
- History: split the ambiguous "Name" column into **Session** (sessionName or short id) and **Project** (cwd basename → repoId fallback). Each row now has a clear identity, and project attribution is independent — matches the reality that subagent linkage is by session UUID (`parentUuid`), not project.

## Test plan
- [x] `make build` (tsc + vite + go build) clean
- [x] `make test` — all packages pass
- [x] `make lint` — clean
- [x] Verified in browser: live-dot visible on ACTIVE and \$/MIN; toggling TODAY/WEEK/MONTH/ALL changes only TOTAL SPEND and CACHE HIT; HISTORY now shows Session + Project columns with disclosure triangle + subagent badge still on the Session column

🤖 Generated with [Claude Code](https://claude.com/claude-code)