### PR TITLE
test: make the suite hermetic & deterministic (Phase 0)

### DIFF
--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -19,8 +19,12 @@ import (
 func newTestClient(t *testing.T, mux *http.ServeMux) (*Client, func()) {
 	t.Helper()
 
-	// Use a temp Unix socket so we don't collide with other tests.
-	sockPath := filepath.Join(t.TempDir(), "docker.sock")
+	// Use a short temp Unix socket path. We deliberately avoid t.TempDir()
+	// because it embeds the (long) test name, and on macOS the Unix socket
+	// path is capped at 104 bytes (sun_path); long names overflow it and
+	// net.Listen fails with "bind: invalid argument". A short MkdirTemp dir
+	// keeps the path well under the limit on both macOS and Linux.
+	sockPath := shortSocketPath(t)
 	ln, err := net.Listen("unix", sockPath)
 	if err != nil {
 		t.Fatalf("listen unix: %v", err)
@@ -36,6 +40,20 @@ func newTestClient(t *testing.T, mux *http.ServeMux) (*Client, func()) {
 		ln.Close()
 	}
 	return client, cleanup
+}
+
+// shortSocketPath returns a short, unique Unix socket path that stays within
+// the 104-byte sun_path limit on macOS. The containing dir is removed on
+// cleanup. t.TempDir() cannot be used here because it embeds the test name,
+// which can push the socket path past the limit and fail net.Listen.
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "dk")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "d.sock")
 }
 
 // ---------- FindClaudePaths tests ----------
@@ -672,8 +690,8 @@ func TestNewClient_UsesUnixSocket(t *testing.T) {
 	t.Parallel()
 
 	// Verify that NewClient returns a non-nil client.
-	dir := t.TempDir()
-	sockPath := filepath.Join(dir, "test.sock")
+	// Use a short socket path to stay within the macOS sun_path limit.
+	sockPath := shortSocketPath(t)
 
 	// Create a real socket so the client can connect.
 	ln, err := net.Listen("unix", sockPath)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -903,14 +903,19 @@ func TestTrendData_AvgSessionTokens(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
-	now := time.Now().UTC()
+	// Anchor both sessions at noon UTC of the previous day. This keeps them
+	// comfortably inside the 7d window while staying far from any UTC day
+	// boundary, so they always land in a single daily bucket regardless of
+	// the wall-clock time at which the test runs (avoids the midnight-boundary
+	// flake that a now-relative offset would introduce near 00:00 UTC).
+	yesterday := time.Now().UTC().AddDate(0, 0, -1)
+	anchor := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 12, 0, 0, 0, time.UTC)
 	// 2 sessions on same day: total tokens per session = input+output+cacheRead+cacheCreate
 	// s1: 100+50+30+10 = 190
 	// s2: 200+100+60+20 = 380
 	// total = 570, avg = 285
-	// Use small offsets to ensure both sessions fall within the same UTC day bucket
-	insertTestSession(t, db, "s1", now.Add(-30*time.Minute), 1.00, 100, 50, 30, 10)
-	insertTestSession(t, db, "s2", now.Add(-15*time.Minute), 2.00, 200, 100, 60, 20)
+	insertTestSession(t, db, "s1", anchor, 1.00, 100, 50, 30, 10)
+	insertTestSession(t, db, "s2", anchor.Add(15*time.Minute), 2.00, 200, 100, 60, 20)
 
 	result, err := db.TrendData("7d", "")
 	if err != nil {

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -122,10 +122,10 @@ func TestWatcher_EmitsEventsForAppendedLines(t *testing.T) {
 	}
 	f.Close()
 
-	w, err := New([]string{dir})
-	if err != nil {
-		t.Fatalf("creating watcher: %v", err)
-	}
+	// Use newTestWatcher to watch ONLY the temp dir. Using New() would prepend
+	// defaultBasePaths (~/.claude/projects/ etc.), causing the watcher to emit
+	// events for real host session files and making assertions non-hermetic.
+	w := newTestWatcher(t, []string{dir})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
## Phase 0 of the audit follow-up — trustworthy test suite

First of a 4-MR series implementing the [audit roadmap](../blob/fix/test-suite-hermeticity/docs/AUDIT-2026-05-29.md). **Test-only changes** — no product behavior is modified. The goal is a green, hermetic `go test ./...` on a developer machine (CI on a clean runner was already green, which is why these gaps were invisible).

### What was failing on a dev machine (and why CI didn't catch it)
| Test | Root cause | Fix |
|---|---|---|
| `watcher.TestWatcher_EmitsEventsForAppendedLines` | Built the watcher via `New()`, which prepends `defaultBasePaths` (`~/.claude/projects/`). The watcher then emitted events for **real host transcripts** (including live workflow-subagent residue) instead of the synthetic temp-dir line, so `SessionID`/`ProjectDir` assertions flaked. | Use the existing hermetic `newTestWatcher` helper that watches **only** the temp dir. |
| `docker.TestFindClaudePaths`, `…JSONStructureVariants`, `TestStopContainer`, `TestNewClient_UsesUnixSocket` | **Not** a missing Docker daemon — the tests run a fake HTTP server over a temp unix socket. The socket path came from `t.TempDir()`, which embeds the long subtest name and overflows the **macOS 104-byte `sun_path` limit** → `net.Listen: bind: invalid argument`. | Add a `shortSocketPath` helper (`os.MkdirTemp`) that stays well under the limit on macOS and Linux. |
| `store.TestTrendData_AvgSessionTokens` | Latent flake: timestamps anchored at `now-30m/-15m` split across two UTC daily buckets when run just after `00:00 UTC`. | Anchor both sessions at **noon UTC of the previous day** — deterministic regardless of wall-clock run time. |

### Verification
- `go test ./internal/... -count=1` → all 10 packages green
- `go vet ./internal/...` → clean
- CI unaffected: pure `_test.go` changes; the new socket path is also under Linux's 108-byte limit.

### Notes
- No product (`.go` non-test) files touched; no product bugs uncovered/deferred.
- Includes `docs/AUDIT-2026-05-29.md` — the full audit + 4-phase roadmap that motivates MRs 2–4 (workflow/session attribution → first-class workflow logging → cleanup). Drop that commit if you'd rather not vendor the doc.

Implemented and self-reviewed via an adversarial workflow (code-review + silent-failure + test-quality passes); all three returned *ship-it*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)