### PR TITLE
fix: attribute Task subagent & Workflow sessions to their parent (Phase 1)

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -260,17 +260,20 @@ func (p *Pipeline) applyEvent(s *session.Session, msg *parser.Event, ev watcher.
 // applyRepoResolution persists the resolved repo and copies CWD/branch/model metadata.
 func (p *Pipeline) applyRepoResolution(s *session.Session, msg *parser.Event, r *repo.Repo) {
 	if r != nil {
+		newRank := r.SourceRank()
 		// First resolution for this session.
 		if s.RepoID == "" {
 			s.RepoID = r.ID
-			s.SetRepoFromGit(r.FromGit)
+			s.SetRepoSourceRank(newRank)
 			if err := p.db.UpsertRepo(r); err != nil {
 				log.Printf("upsert repo error: %v", err)
 			}
-		} else if r.FromGit && !s.RepoFromGit() && r.ID != s.RepoID {
-			// Upgrade an earlier non-git fallback to an authoritative git repo.
+		} else if r.ID != s.RepoID && newRank > s.RepoSourceRank() {
+			// Upgrade to a strictly more authoritative resolution: a non-git
+			// fallback can be upgraded by a git resolution, and a git toplevel
+			// basename can be upgraded by a git remote origin. Never downgrades.
 			s.RepoID = r.ID
-			s.SetRepoFromGit(true)
+			s.SetRepoSourceRank(newRank)
 			if err := p.db.UpsertRepo(r); err != nil {
 				log.Printf("upsert repo error: %v", err)
 			}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -259,10 +259,21 @@ func (p *Pipeline) applyEvent(s *session.Session, msg *parser.Event, ev watcher.
 
 // applyRepoResolution persists the resolved repo and copies CWD/branch/model metadata.
 func (p *Pipeline) applyRepoResolution(s *session.Session, msg *parser.Event, r *repo.Repo) {
-	if r != nil && s.RepoID == "" {
-		s.RepoID = r.ID
-		if err := p.db.UpsertRepo(r); err != nil {
-			log.Printf("upsert repo error: %v", err)
+	if r != nil {
+		// First resolution for this session.
+		if s.RepoID == "" {
+			s.RepoID = r.ID
+			s.SetRepoFromGit(r.FromGit)
+			if err := p.db.UpsertRepo(r); err != nil {
+				log.Printf("upsert repo error: %v", err)
+			}
+		} else if r.FromGit && !s.RepoFromGit() && r.ID != s.RepoID {
+			// Upgrade an earlier non-git fallback to an authoritative git repo.
+			s.RepoID = r.ID
+			s.SetRepoFromGit(true)
+			if err := p.db.UpsertRepo(r); err != nil {
+				log.Printf("upsert repo error: %v", err)
+			}
 		}
 	}
 
@@ -332,19 +343,44 @@ func (p *Pipeline) resolveParentID(msg *parser.Event, ev watcher.Event) string {
 		return ""
 	}
 
-	// For subagent events: prefer direct UUID lookup.
+	// For subagent events: prefer the in-content sessionId, then direct UUID lookup.
 	if msg.IsSidechain || msg.ParentUUID != "" {
+		// Preferred: the in-content sessionId of a sidechain line is the TRUE
+		// parent session UUID for both task subagents (shape 2) and workflow
+		// agents (shape 3). The watcher keyed this row on the filename stem
+		// (ev.SessionID = agent-<id>), so when they differ, msg.SessionID names
+		// the parent. Guard against self-parenting. This is authoritative and
+		// does not depend on the parent already existing in the store, so a
+		// child arriving before its parent is still linked immediately.
+		if msg.IsSidechain && msg.SessionID != "" && msg.SessionID != ev.SessionID {
+			// Also record a deferred parent→child backlink. The child's own
+			// ParentID is set immediately, but parent.Children is only ever
+			// populated by LinkChild, which fires here (line 166) when the
+			// parent already exists, or via resolvePendingLinks once the parent
+			// arrives. During bootstrap/replay a finished subagent's lines may
+			// all be read BEFORE the parent's top-level line, so without this
+			// entry the parent's Children array would never be backfilled.
+			// resolvePendingLinks' `if s.ParentID == ""` guard keeps this
+			// idempotent with the ParentID already set on the child, and it
+			// deletes the entry once the parent→child edge is wired.
+			p.linkMu.Lock()
+			if _, ok := p.pendingParentLinks[ev.SessionID]; !ok {
+				p.pendingParentLinks[ev.SessionID] = msg.SessionID
+			}
+			p.linkMu.Unlock()
+			return msg.SessionID
+		}
 		if msg.ParentUUID != "" {
 			if _, ok := p.sessions.Get(msg.ParentUUID); ok {
 				return msg.ParentUUID
 			}
 		}
 		// Fall back to path-based inference.
-		if sid := parentSessionIDFromPath(ev.FilePath); sid != "" {
+		if sid := parentSessionIDFromPath(ev.FilePath); sid != "" && sid != ev.SessionID {
 			return sid
 		}
 		// Neither source found a parent — record a deferred link.
-		if msg.ParentUUID != "" {
+		if msg.ParentUUID != "" && msg.ParentUUID != ev.SessionID {
 			p.linkMu.Lock()
 			p.pendingParentLinks[ev.SessionID] = msg.ParentUUID
 			p.linkMu.Unlock()
@@ -511,11 +547,22 @@ func skipDetail(event *parser.Event) bool {
 }
 
 // parentSessionIDFromPath extracts the parent session ID from a subagent JSONL path.
-// Subagent files: .../projects/<hash>/<parent-session-id>/subagents/agent-<id>.jsonl
+// It walks UP the directory tree looking for a "subagents" segment and returns the
+// directory immediately above it. This handles both:
+//
+//	shape 2: .../<parent-session-id>/subagents/agent-<id>.jsonl
+//	shape 3: .../<parent-session-id>/subagents/workflows/wf_<id>/agent-<id>.jsonl
 func parentSessionIDFromPath(filePath string) string {
 	dir := filepath.Dir(filePath)
-	if filepath.Base(dir) == "subagents" {
-		return filepath.Base(filepath.Dir(dir))
+	for dir != "." && dir != string(filepath.Separator) {
+		parent := filepath.Dir(dir)
+		if filepath.Base(dir) == "subagents" {
+			return filepath.Base(parent)
+		}
+		if parent == dir { // reached filesystem root; stop
+			break
+		}
+		dir = parent
 	}
 	return ""
 }

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -162,6 +162,7 @@ func TestParentSessionIDFromPath(t *testing.T) {
 		want string
 	}{
 		{"/home/user/.claude/projects/hash/abc-123/subagents/agent-xyz.jsonl", "abc-123"},
+		{"/home/user/.claude/projects/hash/abc-123/subagents/workflows/wf_def/agent-xyz.jsonl", "abc-123"},
 		{"/home/user/.claude/projects/hash/session.jsonl", ""},
 		{"/tmp/test.jsonl", ""},
 	}
@@ -486,6 +487,551 @@ func TestParentLinking_DirectUUID(t *testing.T) {
 	p.linkMu.Unlock()
 	if pending != "" {
 		t.Errorf("no pending link expected; got %q", pending)
+	}
+}
+
+// TestParentLinking_Shape2_InContentSessionID verifies a Task subagent (shape 2)
+// is linked to its parent via the in-content sessionId, which on disk equals the
+// PARENT session UUID while the watcher keys the row on the agent-<id> filename
+// stem. parentUuid is absent (mirrors real disk), the parent is not yet in the
+// store, and the link must still be set immediately (no deferral).
+func TestParentLinking_Shape2_InContentSessionID(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const parentID = "parent-uuid-shape2"
+	const childKey = "agent-aaa"
+	ts := time.Now()
+
+	// In-content sessionId IS the parent UUID; no parentUuid; isSidechain=true.
+	childLine := makeJSONL(t, map[string]interface{}{
+		"type":        "assistant",
+		"timestamp":   ts.Format(time.RFC3339Nano),
+		"sessionId":   parentID,
+		"isSidechain": true,
+		"message": map[string]interface{}{
+			"id":      "msg-child-shape2",
+			"role":    "assistant",
+			"content": "child response",
+			"usage":   map[string]interface{}{"input_tokens": 10, "output_tokens": 5},
+			"model":   "claude-sonnet-4-6",
+		},
+	})
+	p.Process(watcher.Event{
+		SessionID: childKey,
+		FilePath:  "/home/user/.claude/projects/hash/" + parentID + "/subagents/" + childKey + ".jsonl",
+		Line:      childLine,
+		Bootstrap: true,
+	})
+
+	childSess, ok := sessions.Get(childKey)
+	if !ok {
+		t.Fatal("child session not found")
+	}
+	if childSess.ParentID != parentID {
+		t.Errorf("child ParentID = %q, want %q (in-content sessionId)", childSess.ParentID, parentID)
+	}
+
+	// The in-content sessionId resolves the child's ParentID immediately even
+	// before the parent arrives, but a deferred parent→child backlink must also
+	// be recorded so parent.Children is backfilled once the parent shows up.
+	// (parent.Children is only ever populated by LinkChild.)
+	p.linkMu.Lock()
+	pending := p.pendingParentLinks[childKey]
+	p.linkMu.Unlock()
+	if pending != parentID {
+		t.Errorf("pendingParentLinks[%q] = %q, want %q (deferred backlink)", childKey, pending, parentID)
+	}
+
+	// Now process a parent line. resolvePendingLinks should fire and record the
+	// child in parent.Children WITHOUT re-processing the child line.
+	parentLine := makeJSONL(t, map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": ts.Add(time.Second).Format(time.RFC3339Nano),
+		"sessionId": parentID,
+		"message": map[string]interface{}{
+			"id":      "msg-parent-shape2",
+			"role":    "assistant",
+			"content": "parent response",
+			"usage":   map[string]interface{}{"input_tokens": 20, "output_tokens": 10},
+			"model":   "claude-sonnet-4-6",
+		},
+	})
+	p.Process(watcher.Event{
+		SessionID: parentID,
+		FilePath:  "/home/user/.claude/projects/hash/" + parentID + ".jsonl",
+		Line:      parentLine,
+		Bootstrap: true,
+	})
+
+	parentSess, ok := sessions.Get(parentID)
+	if !ok {
+		t.Fatal("parent session not found")
+	}
+	found := false
+	for _, c := range parentSess.Children {
+		if c == childKey {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("parent.Children does not contain %q; got %v", childKey, parentSess.Children)
+	}
+
+	// The deferred link should be cleared after resolution.
+	p.linkMu.Lock()
+	remaining := p.pendingParentLinks[childKey]
+	p.linkMu.Unlock()
+	if remaining != "" {
+		t.Errorf("pendingParentLinks[%q] should be cleared after resolution; got %q", childKey, remaining)
+	}
+}
+
+// TestParentLinking_Shape3_Workflow verifies a workflow agent (shape 3) is linked
+// to its parent via the in-content sessionId. Previously this regressed to "" both
+// because parentUuid is absent on disk and because the path inference did not walk
+// up past the wf_<id> directory. With P0-2 the in-content sessionId resolves it.
+func TestParentLinking_Shape3_Workflow(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const parentID = "parent-uuid-shape3"
+	const childKey = "agent-w1"
+	ts := time.Now()
+
+	childLine := makeJSONL(t, map[string]interface{}{
+		"type":        "assistant",
+		"timestamp":   ts.Format(time.RFC3339Nano),
+		"sessionId":   parentID,
+		"isSidechain": true,
+		"message": map[string]interface{}{
+			"id":      "msg-child-shape3",
+			"role":    "assistant",
+			"content": "workflow agent response",
+			"usage":   map[string]interface{}{"input_tokens": 10, "output_tokens": 5},
+			"model":   "claude-sonnet-4-6",
+		},
+	})
+	p.Process(watcher.Event{
+		SessionID: childKey,
+		FilePath:  "/home/user/.claude/projects/hash/" + parentID + "/subagents/workflows/wf_x/" + childKey + ".jsonl",
+		Line:      childLine,
+		Bootstrap: true,
+	})
+
+	childSess, ok := sessions.Get(childKey)
+	if !ok {
+		t.Fatal("child session not found")
+	}
+	if childSess.ParentID != parentID {
+		t.Errorf("workflow agent ParentID = %q, want %q", childSess.ParentID, parentID)
+	}
+}
+
+// TestParentLinking_InContent_ChildBeforeParent_BackfillsChildren is the
+// regression guard for the out-of-order (child-before-parent) ordering that
+// happens during bootstrap/replay: a finished subagent's lines may all be read
+// BEFORE the parent's top-level <uuid>.jsonl line. The in-content sessionId sets
+// the child's ParentID immediately, but parent.Children must ALSO be backfilled
+// once the parent arrives — WITHOUT re-processing the child line (mirroring the
+// TestParentLinking_DeferredUUID contract for the parentUuid path). Covers both
+// shape 2 (task subagent) and shape 3 (workflow agent) file layouts.
+func TestParentLinking_InContent_ChildBeforeParent_BackfillsChildren(t *testing.T) {
+	cases := []struct {
+		name     string
+		childKey string
+		childDir string // directory holding the agent JSONL, relative to the project hash dir
+	}{
+		{
+			name:     "shape2_task_subagent",
+			childKey: "agent-ooo2",
+			childDir: "subagents",
+		},
+		{
+			name:     "shape3_workflow_agent",
+			childKey: "agent-ooo3",
+			childDir: "subagents/workflows/wf_z",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			sessions := session.NewStore()
+			resolver := repo.NewResolver()
+
+			p := New(sessions, db, resolver, nil)
+			defer p.Stop()
+
+			const parentID = "parent-uuid-ooo"
+			ts := time.Now()
+
+			childLine := makeJSONL(t, map[string]interface{}{
+				"type":        "assistant",
+				"timestamp":   ts.Format(time.RFC3339Nano),
+				"sessionId":   parentID, // in-content sessionId == parent UUID on disk
+				"isSidechain": true,
+				"message": map[string]interface{}{
+					"id":      "msg-" + tc.childKey,
+					"role":    "assistant",
+					"content": "agent response",
+					"usage":   map[string]interface{}{"input_tokens": 10, "output_tokens": 5},
+					"model":   "claude-sonnet-4-6",
+				},
+			})
+
+			// Step 1: process the CHILD first; the parent session does not exist yet.
+			p.Process(watcher.Event{
+				SessionID: tc.childKey,
+				FilePath:  "/home/user/.claude/projects/hash/" + parentID + "/" + tc.childDir + "/" + tc.childKey + ".jsonl",
+				Line:      childLine,
+				Bootstrap: true,
+			})
+
+			childSess, ok := sessions.Get(tc.childKey)
+			if !ok {
+				t.Fatal("child session not found")
+			}
+			if childSess.ParentID != parentID {
+				t.Errorf("child ParentID = %q, want %q", childSess.ParentID, parentID)
+			}
+
+			// Step 2: process the PARENT line. Do NOT re-process the child.
+			parentLine := makeJSONL(t, map[string]interface{}{
+				"type":      "assistant",
+				"timestamp": ts.Add(time.Second).Format(time.RFC3339Nano),
+				"sessionId": parentID,
+				"message": map[string]interface{}{
+					"id":      "msg-parent-ooo",
+					"role":    "assistant",
+					"content": "parent response",
+					"usage":   map[string]interface{}{"input_tokens": 20, "output_tokens": 10},
+					"model":   "claude-sonnet-4-6",
+				},
+			})
+			p.Process(watcher.Event{
+				SessionID: parentID,
+				FilePath:  "/home/user/.claude/projects/hash/" + parentID + ".jsonl",
+				Line:      parentLine,
+				Bootstrap: true,
+			})
+
+			// The parent's Children must now contain the child, backfilled by the
+			// deferred link via resolvePendingLinks — no child re-processing.
+			parentSess, ok := sessions.Get(parentID)
+			if !ok {
+				t.Fatal("parent session not found")
+			}
+			found := false
+			for _, c := range parentSess.Children {
+				if c == tc.childKey {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("parent.Children does not contain %q after parent arrival (no child re-process); got %v", tc.childKey, parentSess.Children)
+			}
+
+			// The deferred link should be cleared after resolution.
+			p.linkMu.Lock()
+			remaining := p.pendingParentLinks[tc.childKey]
+			p.linkMu.Unlock()
+			if remaining != "" {
+				t.Errorf("pendingParentLinks[%q] should be cleared after resolution; got %q", tc.childKey, remaining)
+			}
+		})
+	}
+}
+
+// TestParentLinking_TwoAgentsShareParent verifies that two distinct agents (one a
+// task subagent, one a workflow agent) carrying the same in-content sessionId both
+// link to the same parent session.
+func TestParentLinking_TwoAgentsShareParent(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const parentID = "shared-parent-uuid"
+	ts := time.Now()
+
+	mkChild := func(key string) []byte {
+		return makeJSONL(t, map[string]interface{}{
+			"type":        "assistant",
+			"timestamp":   ts.Format(time.RFC3339Nano),
+			"sessionId":   parentID,
+			"isSidechain": true,
+			"message": map[string]interface{}{
+				"id":      "msg-" + key,
+				"role":    "assistant",
+				"content": "agent response",
+				"usage":   map[string]interface{}{"input_tokens": 10, "output_tokens": 5},
+				"model":   "claude-sonnet-4-6",
+			},
+		})
+	}
+
+	p.Process(watcher.Event{
+		SessionID: "agent-1",
+		FilePath:  "/home/user/.claude/projects/hash/" + parentID + "/subagents/agent-1.jsonl",
+		Line:      mkChild("agent-1"),
+		Bootstrap: true,
+	})
+	p.Process(watcher.Event{
+		SessionID: "agent-2",
+		FilePath:  "/home/user/.claude/projects/hash/" + parentID + "/subagents/workflows/wf_y/agent-2.jsonl",
+		Line:      mkChild("agent-2"),
+		Bootstrap: true,
+	})
+
+	for _, key := range []string{"agent-1", "agent-2"} {
+		sess, ok := sessions.Get(key)
+		if !ok {
+			t.Fatalf("session %q not found", key)
+		}
+		if sess.ParentID != parentID {
+			t.Errorf("%q ParentID = %q, want %q", key, sess.ParentID, parentID)
+		}
+	}
+}
+
+// TestParentLinking_NoSelfParent verifies a sidechain line never self-parents: when
+// the in-content sessionId equals ev.SessionID, ParentID stays empty and no deferred
+// self-link is recorded — including when path inference would also yield ev.SessionID.
+func TestParentLinking_NoSelfParent(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const sameID = "same-id"
+	ts := time.Now()
+
+	line := makeJSONL(t, map[string]interface{}{
+		"type":        "assistant",
+		"timestamp":   ts.Format(time.RFC3339Nano),
+		"sessionId":   sameID,
+		"isSidechain": true,
+		"message": map[string]interface{}{
+			"id":      "msg-self",
+			"role":    "assistant",
+			"content": "response",
+			"usage":   map[string]interface{}{"input_tokens": 10, "output_tokens": 5},
+			"model":   "claude-sonnet-4-6",
+		},
+	})
+	// FilePath path inference would also yield "same-id" (dir above subagents),
+	// confirming the sid != ev.SessionID guard.
+	p.Process(watcher.Event{
+		SessionID: sameID,
+		FilePath:  "/home/user/.claude/projects/hash/" + sameID + "/subagents/" + sameID + ".jsonl",
+		Line:      line,
+		Bootstrap: true,
+	})
+
+	sess, ok := sessions.Get(sameID)
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if sess.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty (must never self-parent)", sess.ParentID)
+	}
+	p.linkMu.Lock()
+	pending := p.pendingParentLinks[sameID]
+	p.linkMu.Unlock()
+	if pending != "" {
+		t.Errorf("pendingParentLinks[%q] = %q, want empty (no self deferral)", sameID, pending)
+	}
+}
+
+// TestProcess_NormalSessionUnaffected locks in that a normal (non-sidechain) session
+// whose in-content sessionId equals ev.SessionID is completely unaffected by P0-2:
+// no ParentID is set and no deferred link is recorded.
+func TestProcess_NormalSessionUnaffected(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const sid = "normal-session"
+	line := makeJSONL(t, map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": time.Now().Format(time.RFC3339Nano),
+		"sessionId": sid,
+		"message": map[string]interface{}{
+			"id":      "msg-normal",
+			"role":    "assistant",
+			"content": "hello",
+			"usage":   map[string]interface{}{"input_tokens": 10, "output_tokens": 5},
+			"model":   "claude-sonnet-4-6",
+		},
+	})
+	p.Process(watcher.Event{
+		SessionID: sid,
+		FilePath:  "/home/user/.claude/projects/hash/" + sid + ".jsonl",
+		Line:      line,
+		Bootstrap: true,
+	})
+
+	sess, ok := sessions.Get(sid)
+	if !ok {
+		t.Fatal("session not found")
+	}
+	if sess.ParentID != "" {
+		t.Errorf("normal session ParentID = %q, want empty", sess.ParentID)
+	}
+	p.linkMu.Lock()
+	pending := p.pendingParentLinks[sid]
+	p.linkMu.Unlock()
+	if pending != "" {
+		t.Errorf("pendingParentLinks[%q] = %q, want empty", sid, pending)
+	}
+}
+
+// TestApplyRepoResolution_UpgradesFallbackToGit verifies that a session whose first
+// repo resolution was a non-git fallback is upgraded to an authoritative git repo
+// when a later resolution arrives with FromGit=true and a different ID.
+func TestApplyRepoResolution_UpgradesFallbackToGit(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const sid = "upgrade-session"
+	fallback := &repo.Repo{ID: "my-project", Name: "my-project", FromGit: false}
+	gitRepo := &repo.Repo{ID: "github.com/acme/my-project", Name: "my-project", URL: "git@github.com:acme/my-project.git", FromGit: true}
+
+	// First resolution: non-git fallback.
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, fallback)
+	})
+	sess, _ := sessions.Get(sid)
+	if sess.RepoID != "my-project" {
+		t.Fatalf("after fallback: RepoID = %q, want %q", sess.RepoID, "my-project")
+	}
+	if sess.RepoFromGit() {
+		t.Error("after fallback: RepoFromGit() = true, want false")
+	}
+
+	// Second resolution: git-backed, different ID -> upgrade.
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, gitRepo)
+	})
+	sess, _ = sessions.Get(sid)
+	if sess.RepoID != "github.com/acme/my-project" {
+		t.Errorf("after upgrade: RepoID = %q, want %q", sess.RepoID, "github.com/acme/my-project")
+	}
+	if !sess.RepoFromGit() {
+		t.Error("after upgrade: RepoFromGit() = false, want true")
+	}
+}
+
+// TestApplyRepoResolution_NoDowngradeOrThrash verifies that once a git-backed repo
+// is set, a subsequent non-git fallback does NOT replace it, and an identical git
+// resolution causes no spurious change.
+func TestApplyRepoResolution_NoDowngradeOrThrash(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const sid = "stable-git-session"
+	gitRepo := &repo.Repo{ID: "github.com/acme/widget", Name: "widget", URL: "https://github.com/acme/widget", FromGit: true}
+	fallback := &repo.Repo{ID: "widget", Name: "widget", FromGit: false}
+
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, gitRepo)
+	})
+	sess, _ := sessions.Get(sid)
+	if sess.RepoID != "github.com/acme/widget" || !sess.RepoFromGit() {
+		t.Fatalf("setup: RepoID=%q fromGit=%v", sess.RepoID, sess.RepoFromGit())
+	}
+
+	// A non-git fallback must NOT downgrade.
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, fallback)
+	})
+	sess, _ = sessions.Get(sid)
+	if sess.RepoID != "github.com/acme/widget" {
+		t.Errorf("after fallback attempt: RepoID = %q, want unchanged %q", sess.RepoID, "github.com/acme/widget")
+	}
+	if !sess.RepoFromGit() {
+		t.Error("after fallback attempt: RepoFromGit() flipped to false")
+	}
+
+	// An identical git resolution must cause no change (r.ID == s.RepoID guard).
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, gitRepo)
+	})
+	sess, _ = sessions.Get(sid)
+	if sess.RepoID != "github.com/acme/widget" {
+		t.Errorf("after identical git: RepoID = %q, want %q", sess.RepoID, "github.com/acme/widget")
+	}
+}
+
+// TestApplyRepoResolution_RestartReupsertPreservesMetadata ties P1-1 and P1-2 at the
+// pipeline layer: after a full git resolution is persisted, a restart-shaped re-upsert
+// (a cache-hit Repo carrying only the ID, FromGit=false) must not blank the stored
+// repo's Name/URL.
+func TestApplyRepoResolution_RestartReupsertPreservesMetadata(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const id = "github.com/acme/widget"
+	gitRepo := &repo.Repo{ID: id, Name: "widget", URL: "https://github.com/acme/widget", FromGit: true}
+
+	sessions.Upsert("sess-a", func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, gitRepo)
+	})
+
+	// Simulate restart: a new session for a cwd whose cache entry only has the ID.
+	cacheHit := &repo.Repo{ID: id} // empty Name/URL, FromGit=false
+	sessions.Upsert("sess-b", func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, cacheHit)
+	})
+
+	rows, err := db.ListRepos()
+	if err != nil {
+		t.Fatalf("ListRepos failed: %v", err)
+	}
+	var found bool
+	for _, r := range rows {
+		if r.ID == id {
+			found = true
+			if r.Name != "widget" {
+				t.Errorf("Name = %q, want %q after restart re-upsert", r.Name, "widget")
+			}
+			if r.URL != "https://github.com/acme/widget" {
+				t.Errorf("URL = %q, want %q after restart re-upsert", r.URL, "https://github.com/acme/widget")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("repo %q not found", id)
 	}
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1168,6 +1168,54 @@ func TestApplyRepoResolution_NoDowngradeOrThrash(t *testing.T) {
 	}
 }
 
+// TestApplyRepoResolution_RemoteUpgradesToplevel verifies the provenance ranking
+// (remote > toplevel > fallback): a git toplevel-basename resolution (FromGit, no
+// URL) is upgraded when a git remote-origin resolution (FromGit, with URL) arrives
+// for the same session, and the reverse never downgrades. Guards the review
+// finding that a binary FromGit flag let a toplevel resolution permanently shadow
+// a stronger remote one for the same cwd-set.
+func TestApplyRepoResolution_RemoteUpgradesToplevel(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const sid = "remote-upgrade-session"
+	toplevel := &repo.Repo{ID: "widget", Name: "widget", FromGit: true} // git toplevel basename, no remote URL
+	remote := &repo.Repo{ID: "github.com/acme/widget", Name: "widget", URL: "git@github.com:acme/widget.git", FromGit: true}
+
+	// First: git toplevel basename (rank = SourceGitToplevel).
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, toplevel)
+	})
+	sess, _ := sessions.Get(sid)
+	if sess.RepoID != "widget" || sess.RepoSourceRank() != repo.SourceGitToplevel {
+		t.Fatalf("after toplevel: RepoID=%q rank=%d, want widget/%d", sess.RepoID, sess.RepoSourceRank(), repo.SourceGitToplevel)
+	}
+
+	// Then: git remote origin (rank = SourceGitRemote) -> must upgrade.
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, remote)
+	})
+	sess, _ = sessions.Get(sid)
+	if sess.RepoID != "github.com/acme/widget" {
+		t.Errorf("after remote: RepoID = %q, want github.com/acme/widget (remote should upgrade toplevel)", sess.RepoID)
+	}
+	if sess.RepoSourceRank() != repo.SourceGitRemote {
+		t.Errorf("after remote: rank = %d, want %d", sess.RepoSourceRank(), repo.SourceGitRemote)
+	}
+
+	// A later toplevel resolution must NOT downgrade the remote.
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{}, &repo.Repo{ID: "widget", Name: "widget", FromGit: true})
+	})
+	sess, _ = sessions.Get(sid)
+	if sess.RepoID != "github.com/acme/widget" {
+		t.Errorf("toplevel must not downgrade remote: RepoID = %q, want github.com/acme/widget", sess.RepoID)
+	}
+}
+
 // TestApplyRepoResolution_RestartReupsertPreservesMetadata ties P1-1 and P1-2 at the
 // pipeline layer: after a full git resolution is persisted, a restart-shaped re-upsert
 // (a cache-hit Repo carrying only the ID, FromGit=false) must not blank the stored

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -753,6 +753,185 @@ func TestParentLinking_InContent_ChildBeforeParent_BackfillsChildren(t *testing.
 	}
 }
 
+// TestParentLinking_InContentBeatsParentUuid is the precedence guard for the REAL
+// on-disk shape, where a sidechain line carries BOTH an in-content sessionId (the
+// true parent session UUID) AND a parentUuid (an intra-file message-chain pointer
+// that is NOT a session key). resolveParentID must prefer the in-content sessionId.
+// The decoy parent named by parentUuid is pre-seeded into the store so that an
+// (incorrect) parentUuid-first ordering WOULD resolve to it — if a future refactor
+// moved the parentUuid lookup above the in-content branch, this test fails instead
+// of silently re-breaking every real workflow's parent attribution.
+func TestParentLinking_InContentBeatsParentUuid(t *testing.T) {
+	cases := []struct {
+		name     string
+		childKey string
+		childDir string
+	}{
+		{"shape2_task_subagent", "agent-prec2", "subagents"},
+		{"shape3_workflow_agent", "agent-prec3", "subagents/workflows/wf_p"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			sessions := session.NewStore()
+			resolver := repo.NewResolver()
+			p := New(sessions, db, resolver, nil)
+			defer p.Stop()
+
+			const realParent = "real-parent-uuid"
+			const decoyParent = "decoy-parent-uuid"
+			ts := time.Now()
+
+			// Pre-seed the decoy parent so a parentUuid-first lookup WOULD succeed.
+			decoyLine := makeJSONL(t, map[string]interface{}{
+				"type":      "assistant",
+				"timestamp": ts.Format(time.RFC3339Nano),
+				"sessionId": decoyParent,
+				"message": map[string]interface{}{
+					"id":      "msg-decoy",
+					"role":    "assistant",
+					"content": "decoy",
+					"usage":   map[string]interface{}{"input_tokens": 5, "output_tokens": 5},
+					"model":   "claude-sonnet-4-6",
+				},
+			})
+			p.Process(watcher.Event{SessionID: decoyParent, Line: decoyLine, Bootstrap: true})
+
+			// Child carries BOTH in-content sessionId (real parent) and parentUuid (decoy).
+			childLine := makeJSONL(t, map[string]interface{}{
+				"type":        "assistant",
+				"timestamp":   ts.Add(time.Second).Format(time.RFC3339Nano),
+				"sessionId":   realParent,
+				"parentUuid":  decoyParent,
+				"isSidechain": true,
+				"message": map[string]interface{}{
+					"id":      "msg-" + tc.childKey,
+					"role":    "assistant",
+					"content": "agent response",
+					"usage":   map[string]interface{}{"input_tokens": 10, "output_tokens": 5},
+					"model":   "claude-sonnet-4-6",
+				},
+			})
+			p.Process(watcher.Event{
+				SessionID: tc.childKey,
+				FilePath:  "/home/user/.claude/projects/hash/" + realParent + "/" + tc.childDir + "/" + tc.childKey + ".jsonl",
+				Line:      childLine,
+				Bootstrap: true,
+			})
+
+			childSess, ok := sessions.Get(tc.childKey)
+			if !ok {
+				t.Fatal("child session not found")
+			}
+			if childSess.ParentID != realParent {
+				t.Errorf("child ParentID = %q, want %q (in-content sessionId must beat parentUuid %q)", childSess.ParentID, realParent, decoyParent)
+			}
+		})
+	}
+}
+
+// TestParentLinking_InContent_ParentBeforeChild covers the common live-tailing
+// order: the parent <uuid>.jsonl is read BEFORE a sidechain agent line carrying
+// the in-content sessionId. The parent already exists, so the child must link
+// immediately, parent.Children must contain it, and no deferred link should
+// linger. Mirrors TestParentLinking_DirectUUID but drives the in-content branch
+// (ev.SessionID != msg.SessionID, no parentUuid).
+func TestParentLinking_InContent_ParentBeforeChild(t *testing.T) {
+	cases := []struct {
+		name     string
+		childKey string
+		childDir string
+	}{
+		{"shape2_task_subagent", "agent-pbc2", "subagents"},
+		{"shape3_workflow_agent", "agent-pbc3", "subagents/workflows/wf_q"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := openTestDB(t)
+			sessions := session.NewStore()
+			resolver := repo.NewResolver()
+			p := New(sessions, db, resolver, nil)
+			defer p.Stop()
+
+			const parentID = "parent-pbc-uuid"
+			ts := time.Now()
+
+			// Step 1: parent arrives first.
+			parentLine := makeJSONL(t, map[string]interface{}{
+				"type":      "assistant",
+				"timestamp": ts.Format(time.RFC3339Nano),
+				"sessionId": parentID,
+				"message": map[string]interface{}{
+					"id":      "msg-parent-pbc",
+					"role":    "assistant",
+					"content": "parent response",
+					"usage":   map[string]interface{}{"input_tokens": 20, "output_tokens": 10},
+					"model":   "claude-sonnet-4-6",
+				},
+			})
+			p.Process(watcher.Event{
+				SessionID: parentID,
+				FilePath:  "/home/user/.claude/projects/hash/" + parentID + ".jsonl",
+				Line:      parentLine,
+				Bootstrap: true,
+			})
+
+			// Step 2: child sidechain line, in-content sessionId == parent, no parentUuid.
+			childLine := makeJSONL(t, map[string]interface{}{
+				"type":        "assistant",
+				"timestamp":   ts.Add(time.Second).Format(time.RFC3339Nano),
+				"sessionId":   parentID,
+				"isSidechain": true,
+				"message": map[string]interface{}{
+					"id":      "msg-" + tc.childKey,
+					"role":    "assistant",
+					"content": "agent response",
+					"usage":   map[string]interface{}{"input_tokens": 10, "output_tokens": 5},
+					"model":   "claude-sonnet-4-6",
+				},
+			})
+			p.Process(watcher.Event{
+				SessionID: tc.childKey,
+				FilePath:  "/home/user/.claude/projects/hash/" + parentID + "/" + tc.childDir + "/" + tc.childKey + ".jsonl",
+				Line:      childLine,
+				Bootstrap: true,
+			})
+
+			childSess, ok := sessions.Get(tc.childKey)
+			if !ok {
+				t.Fatal("child session not found")
+			}
+			if childSess.ParentID != parentID {
+				t.Errorf("child ParentID = %q, want %q", childSess.ParentID, parentID)
+			}
+
+			parentSess, ok := sessions.Get(parentID)
+			if !ok {
+				t.Fatal("parent session not found")
+			}
+			found := false
+			for _, c := range parentSess.Children {
+				if c == tc.childKey {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("parent.Children does not contain %q; got %v", tc.childKey, parentSess.Children)
+			}
+
+			// Parent already existed, so resolvePendingLinks must clear the deferred
+			// backlink within the same Process call.
+			p.linkMu.Lock()
+			remaining := p.pendingParentLinks[tc.childKey]
+			p.linkMu.Unlock()
+			if remaining != "" {
+				t.Errorf("pendingParentLinks[%q] should be cleared (parent already present); got %q", tc.childKey, remaining)
+			}
+		})
+	}
+}
+
 // TestParentLinking_TwoAgentsShareParent verifies that two distinct agents (one a
 // task subagent, one a workflow agent) carrying the same in-content sessionId both
 // link to the same parent session.

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -11,3 +11,26 @@ type Repo struct {
 	// NOT persisted.
 	FromGit bool
 }
+
+// Resolution-authority ranks, used to decide whether a later resolution should
+// upgrade an earlier one for the same session (higher wins).
+const (
+	SourceFallback    = 0 // container label or bare basename — no git
+	SourceGitToplevel = 2 // git toplevel basename (FromGit, no remote URL)
+	SourceGitRemote   = 3 // git remote origin (FromGit, has URL) — most authoritative
+)
+
+// SourceRank reports how authoritative this resolution is. A git remote (which
+// carries a URL) outranks a git toplevel basename, which outranks any non-git
+// fallback. Used so a remote-origin resolution can upgrade an earlier
+// toplevel-basename one for the same session (not just a non-git fallback).
+func (r *Repo) SourceRank() int {
+	switch {
+	case r.URL != "":
+		return SourceGitRemote
+	case r.FromGit:
+		return SourceGitToplevel
+	default:
+		return SourceFallback
+	}
+}

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -5,4 +5,9 @@ type Repo struct {
 	ID   string // normalized: "github.com/Zxela/claude-monitor" or fallback
 	Name string // human-readable: "claude-monitor"
 	URL  string // full remote URL, empty for local-only or fallback
+	// FromGit is true when ID/Name/URL were derived from a git remote or git
+	// toplevel (authoritative), false for label/basename fallbacks. It is a
+	// runtime-only hint used to upgrade an earlier fallback resolution; it is
+	// NOT persisted.
+	FromGit bool
 }

--- a/internal/repo/resolver.go
+++ b/internal/repo/resolver.go
@@ -59,13 +59,13 @@ func (r *Resolver) resolve(cwd, label string) *Repo {
 	// Try git remote origin
 	if rawURL, err := gitRemoteURL(cwd); err == nil && rawURL != "" {
 		id, name, fullURL := normalizeRemoteURL(rawURL)
-		return &Repo{ID: id, Name: name, URL: fullURL}
+		return &Repo{ID: id, Name: name, URL: fullURL, FromGit: true}
 	}
 
 	// Fallback: git toplevel basename
 	if toplevel, err := gitToplevel(cwd); err == nil && toplevel != "" {
 		base := filepath.Base(toplevel)
-		return &Repo{ID: base, Name: base}
+		return &Repo{ID: base, Name: base, FromGit: true}
 	}
 
 	// Container fallback: label + basename

--- a/internal/repo/resolver_test.go
+++ b/internal/repo/resolver_test.go
@@ -148,6 +148,75 @@ func TestResolve_ContainerFallback(t *testing.T) {
 	}
 }
 
+func TestResolve_FromGitProvenance(t *testing.T) {
+	// The current working directory is a real git repo, so it must resolve git-backed.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewResolver()
+	got, err := r.Resolve(cwd, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.FromGit {
+		t.Errorf("FromGit = false, want true for git-backed cwd %q (ID=%q)", cwd, got.ID)
+	}
+}
+
+func TestResolve_FromGit_FalseForFallbacks(t *testing.T) {
+	// Non-git temp dir -> basename fallback, FromGit must be false.
+	tmp := t.TempDir()
+	sub := filepath.Join(tmp, "my-project")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewResolver()
+	got, err := r.Resolve(sub, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.FromGit {
+		t.Error("FromGit = true, want false for basename fallback")
+	}
+
+	// Container label fallback must also be non-git.
+	ws := filepath.Join(tmp, "workspace")
+	if err := os.Mkdir(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	r2 := NewResolver()
+	gotC, err := r2.Resolve(ws, "docker-host")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotC.FromGit {
+		t.Error("FromGit = true, want false for container-label fallback")
+	}
+}
+
+func TestCache_PreservesFromGit(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := NewResolver()
+	resolved, err := r.Resolve(cwd, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := r.Cache()
+	copied, ok := c[cwd]
+	if !ok {
+		t.Fatalf("cwd %q not present in Cache()", cwd)
+	}
+	if copied.FromGit != resolved.FromGit {
+		t.Errorf("Cache() copy FromGit = %v, want %v", copied.FromGit, resolved.FromGit)
+	}
+}
+
 func TestClearCache(t *testing.T) {
 	r := NewResolver()
 	r.LoadCache(map[string]string{

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -58,14 +58,19 @@ type Session struct {
 	Version        string           `json:"version,omitempty"`
 	Entrypoint     string           `json:"entrypoint,omitempty"`
 	SourceFile     string           `json:"-"` // JSONL file path currently providing events (not serialized)
-	repoFromGit    bool             `json:"-"` // true when RepoID was resolved from git (authoritative); runtime-only, not persisted
+	repoSourceRank int              `json:"-"` // resolution-authority rank of RepoID (repo.Source*); runtime-only, not persisted
 }
 
-// RepoFromGit reports whether the current RepoID came from an authoritative git resolution.
-func (s *Session) RepoFromGit() bool { return s.repoFromGit }
+// RepoSourceRank reports the resolution-authority rank of the current RepoID
+// (see repo.Source* constants). Higher means more authoritative.
+func (s *Session) RepoSourceRank() int { return s.repoSourceRank }
 
-// SetRepoFromGit records repo-resolution provenance.
-func (s *Session) SetRepoFromGit(v bool) { s.repoFromGit = v }
+// SetRepoSourceRank records the resolution-authority rank of the current RepoID.
+func (s *Session) SetRepoSourceRank(rank int) { s.repoSourceRank = rank }
+
+// RepoFromGit reports whether the current RepoID came from an authoritative git
+// resolution (git remote or toplevel), as opposed to a non-git fallback.
+func (s *Session) RepoFromGit() bool { return s.repoSourceRank >= 2 }
 
 // HasSeenMessageID reports whether the given key has been recorded.
 func (s *Session) HasSeenMessageID(key string) bool {

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -58,7 +58,14 @@ type Session struct {
 	Version        string           `json:"version,omitempty"`
 	Entrypoint     string           `json:"entrypoint,omitempty"`
 	SourceFile     string           `json:"-"` // JSONL file path currently providing events (not serialized)
+	repoFromGit    bool             `json:"-"` // true when RepoID was resolved from git (authoritative); runtime-only, not persisted
 }
+
+// RepoFromGit reports whether the current RepoID came from an authoritative git resolution.
+func (s *Session) RepoFromGit() bool { return s.repoFromGit }
+
+// SetRepoFromGit records repo-resolution provenance.
+func (s *Session) SetRepoFromGit(v bool) { s.repoFromGit = v }
 
 // HasSeenMessageID reports whether the given key has been recorded.
 func (s *Session) HasSeenMessageID(key string) bool {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -283,7 +283,9 @@ func (d *DB) Ping() error {
 // UpsertRepo inserts or updates a repo record.
 func (d *DB) UpsertRepo(r *repo.Repo) error {
 	_, err := d.db.Exec(`INSERT INTO repos (id, name, url, first_seen) VALUES (?, ?, ?, ?)
-		ON CONFLICT(id) DO UPDATE SET name=excluded.name, url=excluded.url`,
+		ON CONFLICT(id) DO UPDATE SET
+			name = CASE WHEN excluded.name <> '' THEN excluded.name ELSE repos.name END,
+			url  = CASE WHEN excluded.url  <> '' THEN excluded.url  ELSE repos.url  END`,
 		r.ID, r.Name, r.URL, time.Now().Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("UpsertRepo: %w", err)

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -46,6 +46,91 @@ func TestUpsertRepo(t *testing.T) {
 	}
 }
 
+func TestUpsertRepo_DoesNotBlankNameURLOnEmpty(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	const id = "github.com/x/y"
+	full := &repo.Repo{ID: id, Name: "y", URL: "git@github.com:x/y.git"}
+	if err := db.UpsertRepo(full); err != nil {
+		t.Fatalf("UpsertRepo (populated) failed: %v", err)
+	}
+
+	// Re-upsert with empty Name/URL (as a LoadCache cache-hit Repo would produce).
+	if err := db.UpsertRepo(&repo.Repo{ID: id}); err != nil {
+		t.Fatalf("UpsertRepo (empty) failed: %v", err)
+	}
+
+	got := findRepoRow(t, db, id)
+	if got.Name != "y" {
+		t.Errorf("Name = %q, want %q (empty excluded must not blank)", got.Name, "y")
+	}
+	if got.URL != "git@github.com:x/y.git" {
+		t.Errorf("URL = %q, want %q (empty excluded must not blank)", got.URL, "git@github.com:x/y.git")
+	}
+
+	// A non-empty later name DOES overwrite.
+	if err := db.UpsertRepo(&repo.Repo{ID: id, Name: "renamed"}); err != nil {
+		t.Fatalf("UpsertRepo (rename) failed: %v", err)
+	}
+	got = findRepoRow(t, db, id)
+	if got.Name != "renamed" {
+		t.Errorf("Name = %q, want %q (non-empty must overwrite)", got.Name, "renamed")
+	}
+	// URL was empty in the rename upsert, so it must survive.
+	if got.URL != "git@github.com:x/y.git" {
+		t.Errorf("URL = %q, want %q (empty url in rename must not blank)", got.URL, "git@github.com:x/y.git")
+	}
+}
+
+// TestUpsertRepo_RestartReupsertRegression documents the end-to-end restart
+// invariant at the store layer: a fully-populated repo survives a re-upsert that
+// carries empty Name/URL (the shape a LoadCache cache-hit produces after restart).
+func TestUpsertRepo_RestartReupsertRegression(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	const id = "github.com/acme/widget"
+	if err := db.UpsertRepo(&repo.Repo{ID: id, Name: "widget", URL: "https://github.com/acme/widget"}); err != nil {
+		t.Fatalf("seed UpsertRepo failed: %v", err)
+	}
+
+	// Confirm it exists with metadata.
+	before := findRepoRow(t, db, id)
+	if before.Name != "widget" || before.URL != "https://github.com/acme/widget" {
+		t.Fatalf("seed row not as expected: %+v", before)
+	}
+
+	// Simulate the post-restart re-upsert with an empty-metadata cache-hit Repo.
+	if err := db.UpsertRepo(&repo.Repo{ID: id}); err != nil {
+		t.Fatalf("restart re-upsert failed: %v", err)
+	}
+
+	after := findRepoRow(t, db, id)
+	if after.Name != "widget" {
+		t.Errorf("Name = %q, want %q after restart re-upsert", after.Name, "widget")
+	}
+	if after.URL != "https://github.com/acme/widget" {
+		t.Errorf("URL = %q, want %q after restart re-upsert", after.URL, "https://github.com/acme/widget")
+	}
+}
+
+// findRepoRow returns the RepoRow with the given id, failing if not present.
+func findRepoRow(t *testing.T, db *DB, id string) RepoRow {
+	t.Helper()
+	rows, err := db.ListRepos()
+	if err != nil {
+		t.Fatalf("ListRepos failed: %v", err)
+	}
+	for _, r := range rows {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("repo %q not found in ListRepos", id)
+	return RepoRow{}
+}
+
 func TestCwdRepos(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)


### PR DESCRIPTION
## Phase 1 — workflow/subagent session attribution (the core correctness fix)

> **Stacked on #218 (Phase 0).** Base is `fix/test-suite-hermeticity` so this diff shows only Phase 1. Merge #218 first; GitHub will retarget this to `main`.

Fixes both flagged concerns from the audit. Subagent and **Workflows** transcripts were surfacing as bogus top-level sessions named `agent-<id>`, polluting History/List/Graph/Table and inflating session counts. The single root cause is **filename-vs-content `sessionId` attribution**.

### Changes

**P0-1 — `parentSessionIDFromPath` handles the Workflows layout** (`pipeline.go`)
Walks **up** the path to find a `subagents` segment at any depth (root-terminating), so it works for both:
```
shape 2: <parent>/subagents/agent-<id>.jsonl
shape 3: <parent>/subagents/workflows/wf_<id>/agent-<id>.jsonl   ← new, previously returned ""
```

**P0-2 — `resolveParentID` prefers the in-content `sessionId`** (`pipeline.go`)
For sidechain events, the in-content `sessionId` **is** the true parent session UUID for both shapes (verified on disk — `parentUuid` is empty in production, so this is the only reliable signal). The fix:
- sets `ParentID = msg.SessionID` immediately (arrival-order independent), **without re-keying the store** — each agent stays its own row keyed by `ev.SessionID`;
- guards against self-parenting (`msg.SessionID != ev.SessionID`; normal sessions short-circuit earlier and are unaffected);
- **retains a deferred parent→child backlink** so `parent.Children` still backfills when a finished subagent is replayed before its parent line (this addressed a HIGH finding from self-review).

**P1-1 — non-destructive `UpsertRepo`** (`sqlite.go`)
`CASE WHEN excluded.<col> <> '' ...` so a `LoadCache` cache-hit re-upsert after restart no longer wipes `repos.name`/`url`.

**P1-2 — git-provenance repo upgrade** (`repo.go`, `resolver.go`, `session.go`, `pipeline.go`)
`repo.Repo.FromGit` + runtime-only `Session.repoFromGit` let a later authoritative git resolution upgrade an earlier non-git fallback, fixing single-session repo fragmentation.

### Tests
Adds shape-2 **and** shape-3 pipeline fixtures/tests (child→parent linking, two agents sharing a parent, normal-session-unaffected, self-parent guard, child-before-parent backfill), repo restart-survival (P1-1) and git-upgrade (P1-2) tests. `go test ./internal/... -count=1` → all 10 packages green; `go vet ./internal/...` clean. ~700 of 774 changed lines are tests.

### Deliberate deferrals (low risk, transparent)
- **`parentSessionIDFromPath` upward walk is unanchored** — a stray `subagents` path segment at an unexpected depth could in theory mis-attribute. Practical exposure is ~nil: real `.claude/projects` paths can't contain a stray `subagents` segment (the project dir is a single `-`-encoded segment), and after P0-2 this function is only a *secondary fallback* for sidechain events whose in-content `sessionId` is empty (never observed in production). The common negative cases (normal path, non-subagent path) are tested. Candidate for anchoring under `.claude/projects/<hash>` in Phase 3.
- **P1-2 provenance is runtime-only** (not a DB column) — after restart it resets to `false`; benign because post-restart cache hits carry `FromGit=false` (cannot trigger a downgrade) and P1-1 protects the stored name. Persisting it is Phase 2 territory.

Implemented + adversarially self-reviewed (code-review + silent-failure + test-coverage); the one HIGH finding was fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)