### PR TITLE
feat: first-class Claude Code workflow logging & aggregation (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,16 +270,17 @@ Full OpenAPI spec at [`api/openapi.yaml`](api/openapi.yaml). Enable Swagger UI w
 |----------|-------------|
 | `GET /health` | Health check (includes `droppedEvents` counter) |
 | `GET /api/version` | Server version |
-| `GET /api/sessions` | List sessions (supports `?active=true`, `?group=activity`, pagination) |
+| `GET /api/sessions` | List sessions (supports `?active=true`, `?group=activity`, `?repo=`, `?workflow=`, pagination) |
 | `GET /api/sessions/{id}` | Single session lookup (live store, then DB fallback) |
 | `GET /api/sessions/{id}/events` | Session events (supports `?pinned`, `?errors`, `?last=N`, pagination) |
-| `GET /api/sessions/{id}/replay` | Replay manifest (all events, up to 10k) |
+| `GET /api/sessions/{id}/replay` | Replay manifest (session + its child agents, up to 10k events) |
 | `POST /api/sessions/{id}/stop` | Stop Docker container for a session |
 | `GET /api/stats` | Aggregated stats with `?window=` (all, today, week, month) |
 | `GET /api/stats/trends` | Trend data with `?window=` (24h, 7d, 30d) and optional `?repo=` |
 | `GET /api/repos` | Repository list with total costs |
 | `GET /api/repos/{id}/stats` | Per-repo aggregate statistics |
 | `GET /api/repos/{id}/sessions` | Paginated sessions for a repo |
+| `GET /api/workflows` | Workflow list with agent count and total cost |
 | `GET /api/search?q=&limit=` | FTS5 full-text search across sessions |
 | `GET /api/search/full?q=&limit=` | Full-content substring search (slower, searches complete text) |
 | `GET /api/settings` | Get all user-configurable settings |

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: >
     REST and WebSocket API for claude-monitor — a daemon that watches Claude Code
     JSONL session files and broadcasts activity over WebSocket.
-  version: "3.5.0"
+  version: "3.4.0"
 
 servers:
   - url: http://localhost:7700
@@ -95,7 +95,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/VersionResponse"
               example:
-                version: "v3.5.0"
+                version: "v3.4.0"
 
   /api/sessions:
     get:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: >
     REST and WebSocket API for claude-monitor — a daemon that watches Claude Code
     JSONL session files and broadcasts activity over WebSocket.
-  version: "3.1.1"
+  version: "3.5.0"
 
 servers:
   - url: http://localhost:7700
@@ -23,6 +23,8 @@ tags:
     description: Full-text search across sessions
   - name: repos
     description: Repository aggregations
+  - name: workflows
+    description: Claude Code workflow aggregations
   - name: stats
     description: Aggregated statistics and trends
   - name: settings
@@ -93,7 +95,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/VersionResponse"
               example:
-                version: "v3.1.1"
+                version: "v3.5.0"
 
   /api/sessions:
     get:
@@ -130,6 +132,13 @@ paths:
         - name: repo
           in: query
           description: Filter sessions by repository ID (only applies to default/flat mode).
+          schema:
+            type: string
+        - name: workflow
+          in: query
+          description: >
+            Filter sessions to those belonging to a workflow (workflow_id), in
+            default/flat mode. Takes precedence over ?repo= when both are set.
           schema:
             type: string
         - name: limit
@@ -253,7 +262,10 @@ paths:
       summary: Replay manifest for a session
       description: >
         Returns the full ordered list of events for the session from the database
-        (up to 10,000), plus the session ID. Suitable for driving a timeline scrubber.
+        (up to 10,000), plus the session ID. The manifest also includes events
+        from the session's direct children (subagents / workflow agents), merged
+        chronologically, so a parent or workflow root replays as a single unified
+        timeline. Suitable for driving a timeline scrubber.
       operationId: getSessionReplay
       parameters:
         - $ref: "#/components/parameters/SessionId"
@@ -427,6 +439,27 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Session"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/workflows:
+    get:
+      tags: [workflows]
+      summary: List workflows
+      description: >
+        Returns one aggregate row per distinct Claude Code workflow (workflow_id),
+        with the number of agents in the workflow, total cost summed across all
+        its agents (counted once), and the most recent activity timestamp.
+      operationId: listWorkflows
+      responses:
+        "200":
+          description: Array of workflow aggregates
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowRow"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -953,6 +986,19 @@ components:
           type: string
           description: How the session was started (e.g. "cli", "vscode"). Omitted when empty.
           example: "cli"
+        workflowId:
+          type: string
+          description: Workflow this agent session belongs to. Omitted when empty.
+          example: "wf_abc123"
+        agentId:
+          type: string
+          description: Stable agent identifier within a workflow/subagent run (agent-<id>). Omitted when empty.
+          example: "agent-2"
+        agentKind:
+          type: string
+          description: Origin of the session record.
+          enum: [session, subagent, workflow_agent]
+          example: "workflow_agent"
 
     GroupedSessions:
       type: object
@@ -1215,7 +1261,12 @@ components:
 
     ReplayManifest:
       type: object
-      description: Full ordered event list for a session, used to drive a replay timeline.
+      description: >
+        Full ordered event list for a replay timeline. The manifest now includes
+        events from the session AND its direct children (subagents / workflow
+        agents linked via parent_id), merged chronologically, so a parent or
+        workflow root replays as a single unified timeline. The response shape is
+        unchanged.
       required: [sessionId, events]
       properties:
         sessionId:
@@ -1224,9 +1275,35 @@ components:
           example: "abc123def456"
         events:
           type: array
-          description: All events in chronological order (up to 10,000).
+          description: >
+            All events for the session and its direct children, in chronological
+            order (up to 10,000).
           items:
             $ref: "#/components/schemas/EventRow"
+
+    WorkflowRow:
+      type: object
+      description: Aggregate stats for a single Claude Code workflow.
+      required: [workflowId, agentCount, totalCost, lastActive]
+      properties:
+        workflowId:
+          type: string
+          description: Workflow identifier (wf_<id> from the transcript path).
+          example: "wf_abc123"
+        agentCount:
+          type: integer
+          description: Number of agent sessions belonging to this workflow.
+          example: 4
+        totalCost:
+          type: number
+          format: double
+          description: Total cost summed across all agents in the workflow.
+          example: 1.85
+        lastActive:
+          type: string
+          format: date-time
+          description: RFC3339 timestamp of the workflow's most recent agent activity. May be empty.
+          example: "2026-05-29T14:05:00Z"
 
     RepoRow:
       type: object

--- a/cmd/claude-monitor/handlers.go
+++ b/cmd/claude-monitor/handlers.go
@@ -149,9 +149,12 @@ func handleSessions(sessionStore *session.Store, historyDB *store.DB) http.Handl
 		}
 		var rows []store.SessionRow
 		var err error
-		if repoID := q.Get("repo"); repoID != "" {
-			rows, err = historyDB.ListSessionsByRepo(repoID, limit, offset)
-		} else {
+		switch {
+		case q.Get("workflow") != "":
+			rows, err = historyDB.ListSessionsByWorkflow(q.Get("workflow"), limit, offset)
+		case q.Get("repo") != "":
+			rows, err = historyDB.ListSessionsByRepo(q.Get("repo"), limit, offset)
+		default:
 			rows, err = historyDB.ListSessions(limit, offset)
 		}
 		if err != nil {
@@ -343,6 +346,22 @@ func handleRepoSessions(historyDB *store.DB) http.HandlerFunc {
 	}
 }
 
+// handleWorkflows serves GET /api/workflows.
+func handleWorkflows(historyDB *store.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		workflows, err := historyDB.ListWorkflows()
+		if err != nil {
+			log.Printf("list workflows error: %v", err)
+			writeJSONError(w, "failed to list workflows", http.StatusInternalServerError)
+			return
+		}
+		if workflows == nil {
+			workflows = []store.WorkflowRow{}
+		}
+		writeJSON(w, workflows)
+	}
+}
+
 // handleSearch serves GET /api/search.
 func handleSearch(historyDB *store.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -524,7 +543,7 @@ func handleSessionReplay(historyDB *store.DB) http.HandlerFunc {
 		if n, err := strconv.Atoi(q.Get("offset")); err == nil && n >= 0 {
 			offset = n
 		}
-		events, err := historyDB.ListEvents(id, limit, offset)
+		events, err := historyDB.ListReplayEvents(id, limit, offset)
 		if err != nil {
 			writeJSONError(w, "failed to list events", http.StatusInternalServerError)
 			return

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -279,6 +279,7 @@ func main() {
 	dockerEnabled := flag.Bool("docker", false, "auto-discover .claude/projects mounts from running Docker containers")
 	dockerSocket := flag.String("docker-socket", "/var/run/docker.sock", "path to Docker socket")
 	swaggerEnabled := flag.Bool("swagger", false, "serve Swagger UI at /swagger")
+	rebuildHistory := flag.Bool("rebuild-history", false, "re-ingest all historical JSONL from scratch (idempotent; rebuilds dedup from DB) and re-run the v013 identity backfill")
 	// Handle --version before any other initialization.
 	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "-version") {
 		fmt.Printf("claude-monitor %s\n", version)
@@ -318,6 +319,7 @@ Examples:
   claude-monitor                                  # Start with defaults (localhost:7700)
   claude-monitor --port 8080 --watch /extra/path  # Custom port + extra watch dir
   claude-monitor --broadcast --swagger            # All interfaces + Swagger UI
+  claude-monitor --rebuild-history                # Re-scan all history and re-link workflows
 `)
 	}
 
@@ -351,6 +353,27 @@ Examples:
 	historyDB, err := store.Open(filepath.Join(dbDir, "history.db"))
 	if err != nil {
 		log.Fatalf("cannot open database: %v", err)
+	}
+
+	// One-time, idempotent v013 identity backfill: link agent transcripts that
+	// predate Workstream-2 identity stamping (parent_id/workflow_id/agent_id/
+	// agent_kind). Runs synchronously AFTER migrations (inside store.Open) and
+	// BEFORE the watcher's bootstrap scan (fw.Start below), so live ingestion sees
+	// already-linked rows. It is marker-guarded (settings key "backfill_v013_done")
+	// so steady-state startups short-circuit with no walk.
+	//
+	// --rebuild-history forces the backfill to re-run; the actual re-INGEST is
+	// achieved by the watcher reading every tracked file from offset 0 during
+	// bootstrap (idempotent: PersistBatch dedups on (session_id,
+	// COALESCE(message_id,uuid)) and the pipeline rebuilds dedup state from the DB).
+	backfillPaths := store.DefaultBackfillBasePaths()
+	if res, err := historyDB.RunBackfillV013(backfillPaths, *rebuildHistory); err != nil {
+		// Never Fatalf: a partial/failed backfill must not block the daemon. The
+		// marker stays unset so it retries on the next start.
+		log.Printf("warning: backfill v013 failed (will retry next start): %v", err)
+	} else if res.Scanned > 0 || res.Updated > 0 {
+		log.Printf("backfill v013: scanned=%d updated=%d skipped=%d errors=%d",
+			res.Scanned, res.Updated, res.Skipped, res.Errors)
 	}
 
 	// Load model pricing from DB and initialise the parser's active pricing table.
@@ -572,6 +595,7 @@ Examples:
 	mux.HandleFunc("GET /api/repos", handleRepos(historyDB))
 	mux.HandleFunc("GET /api/repos/{id}/stats", handleRepoStats(historyDB))
 	mux.HandleFunc("GET /api/repos/{id}/sessions", handleRepoSessions(historyDB))
+	mux.HandleFunc("GET /api/workflows", handleWorkflows(historyDB))
 	mux.HandleFunc("GET /api/search", handleSearch(historyDB))
 	mux.HandleFunc("GET /api/search/full", handleSearchFull(historyDB))
 	mux.HandleFunc("GET /api/search/combined", handleSearchCombined(historyDB))

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -367,7 +367,9 @@ Examples:
 	// (idempotent — PersistBatch dedups on (session_id, COALESCE(message_id,uuid))
 	// and the pipeline rebuilds dedup state from the DB). --rebuild-history's only
 	// effect is forcing THIS v013 identity backfill to re-run past its done-marker.
-	backfillPaths := store.DefaultBackfillBasePaths()
+	// Include any --watch dirs so agent transcripts under custom watch paths are
+	// linked too (the done-marker would otherwise permanently skip them).
+	backfillPaths := append(store.DefaultBackfillBasePaths(), []string(extraPaths)...)
 	if res, err := historyDB.RunBackfillV013(backfillPaths, *rebuildHistory); err != nil {
 		// Never Fatalf: a partial/failed backfill must not block the daemon. The
 		// marker stays unset so it retries on the next start.

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -279,7 +279,7 @@ func main() {
 	dockerEnabled := flag.Bool("docker", false, "auto-discover .claude/projects mounts from running Docker containers")
 	dockerSocket := flag.String("docker-socket", "/var/run/docker.sock", "path to Docker socket")
 	swaggerEnabled := flag.Bool("swagger", false, "serve Swagger UI at /swagger")
-	rebuildHistory := flag.Bool("rebuild-history", false, "re-ingest all historical JSONL from scratch (idempotent; rebuilds dedup from DB) and re-run the v013 identity backfill")
+	rebuildHistory := flag.Bool("rebuild-history", false, "force the one-time v013 workflow-identity backfill to re-run (ignores its done-marker). Historical JSONL is re-ingested on every startup regardless of this flag.")
 	// Handle --version before any other initialization.
 	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "-version") {
 		fmt.Printf("claude-monitor %s\n", version)
@@ -319,7 +319,7 @@ Examples:
   claude-monitor                                  # Start with defaults (localhost:7700)
   claude-monitor --port 8080 --watch /extra/path  # Custom port + extra watch dir
   claude-monitor --broadcast --swagger            # All interfaces + Swagger UI
-  claude-monitor --rebuild-history                # Re-scan all history and re-link workflows
+  claude-monitor --rebuild-history                # Force the workflow-identity backfill to re-run
 `)
 	}
 
@@ -362,10 +362,11 @@ Examples:
 	// already-linked rows. It is marker-guarded (settings key "backfill_v013_done")
 	// so steady-state startups short-circuit with no walk.
 	//
-	// --rebuild-history forces the backfill to re-run; the actual re-INGEST is
-	// achieved by the watcher reading every tracked file from offset 0 during
-	// bootstrap (idempotent: PersistBatch dedups on (session_id,
-	// COALESCE(message_id,uuid)) and the pipeline rebuilds dedup state from the DB).
+	// Re-INGEST of historical JSONL happens on EVERY startup regardless of this
+	// flag: the watcher reads every tracked file from offset 0 during bootstrap
+	// (idempotent — PersistBatch dedups on (session_id, COALESCE(message_id,uuid))
+	// and the pipeline rebuilds dedup state from the DB). --rebuild-history's only
+	// effect is forcing THIS v013 identity backfill to re-run past its done-marker.
 	backfillPaths := store.DefaultBackfillBasePaths()
 	if res, err := historyDB.RunBackfillV013(backfillPaths, *rebuildHistory); err != nil {
 		// Never Fatalf: a partial/failed backfill must not block the daemon. The

--- a/cmd/claude-monitor/main_test.go
+++ b/cmd/claude-monitor/main_test.go
@@ -476,3 +476,42 @@ func TestCacheClear(t *testing.T) {
 		t.Error("expected ok=true in response")
 	}
 }
+
+// TestWorkflows verifies GET /api/workflows returns 200 and a JSON array
+// (empty on a fresh DB, not null).
+func TestWorkflows(t *testing.T) {
+	t.Parallel()
+	var body []json.RawMessage
+	getJSON(t, "/api/workflows", &body)
+	if body == nil {
+		t.Error("expected non-nil array, got null")
+	}
+}
+
+// TestSessionsWorkflowFilter verifies GET /api/sessions?workflow=... is accepted
+// and returns a JSON array.
+func TestSessionsWorkflowFilter(t *testing.T) {
+	t.Parallel()
+	var body []json.RawMessage
+	getJSON(t, "/api/sessions?workflow=wf_nonexistent", &body)
+	if body == nil {
+		t.Error("expected non-nil array, got null")
+	}
+}
+
+// TestSessionReplay verifies GET /api/sessions/{id}/replay returns 200 with the
+// {sessionId, events} envelope even for an unknown session (empty events, not null).
+func TestSessionReplay(t *testing.T) {
+	t.Parallel()
+	var body struct {
+		SessionID string            `json:"sessionId"`
+		Events    []json.RawMessage `json:"events"`
+	}
+	getJSON(t, "/api/sessions/replay-unknown-id/replay", &body)
+	if body.SessionID != "replay-unknown-id" {
+		t.Errorf("sessionId = %q, want replay-unknown-id", body.SessionID)
+	}
+	if body.Events == nil {
+		t.Error("events should be non-nil array")
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -253,8 +253,24 @@ func (p *Pipeline) applyEvent(s *session.Session, msg *parser.Event, ev watcher.
 	p.applyRepoResolution(s, msg, r)
 	p.applySessionMeta(s, msg, ev)
 	p.applyParentDetection(s, msg, ev, resolvedParentID)
+	p.applyWorkflowIdentity(s, ev)
 	p.applyCostDedup(s, msg)
 	p.applyStatusUpdate(s, msg, ev)
+}
+
+// applyWorkflowIdentity records the workflow/agent identity derived by the
+// watcher from the file path. AgentKind/AgentID/WorkflowID are set-once (never
+// overwritten with empty) so a later non-identity line cannot clear them.
+func (p *Pipeline) applyWorkflowIdentity(s *session.Session, ev watcher.Event) {
+	if ev.AgentKind != "" && s.AgentKind == "" {
+		s.AgentKind = ev.AgentKind
+	}
+	if ev.AgentID != "" && s.AgentID == "" {
+		s.AgentID = ev.AgentID
+	}
+	if ev.WorkflowID != "" && s.WorkflowID == "" {
+		s.WorkflowID = ev.WorkflowID
+	}
 }
 
 // applyRepoResolution persists the resolved repo and copies CWD/branch/model metadata.

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -521,11 +521,16 @@ func TestParentLinking_Shape2_InContentSessionID(t *testing.T) {
 			"model":   "claude-sonnet-4-6",
 		},
 	})
+	// AgentKind/AgentID are stamped by watcher.emit in production; in unit tests
+	// Process receives the Event directly, so populate them with literal strings
+	// (the pipeline package must not import the watcher kind constants).
 	p.Process(watcher.Event{
 		SessionID: childKey,
 		FilePath:  "/home/user/.claude/projects/hash/" + parentID + "/subagents/" + childKey + ".jsonl",
 		Line:      childLine,
 		Bootstrap: true,
+		AgentKind: "subagent",
+		AgentID:   childKey,
 	})
 
 	childSess, ok := sessions.Get(childKey)
@@ -534,6 +539,15 @@ func TestParentLinking_Shape2_InContentSessionID(t *testing.T) {
 	}
 	if childSess.ParentID != parentID {
 		t.Errorf("child ParentID = %q, want %q (in-content sessionId)", childSess.ParentID, parentID)
+	}
+	if childSess.AgentKind != "subagent" {
+		t.Errorf("child AgentKind = %q, want subagent", childSess.AgentKind)
+	}
+	if childSess.AgentID != childKey {
+		t.Errorf("child AgentID = %q, want %q", childSess.AgentID, childKey)
+	}
+	if childSess.WorkflowID != "" {
+		t.Errorf("child WorkflowID = %q, want empty (shape 2 has no workflow)", childSess.WorkflowID)
 	}
 
 	// The in-content sessionId resolves the child's ParentID immediately even
@@ -621,11 +635,16 @@ func TestParentLinking_Shape3_Workflow(t *testing.T) {
 			"model":   "claude-sonnet-4-6",
 		},
 	})
+	// Workflow identity is stamped by watcher.emit in production; populate the
+	// Event fields with literal strings here (see shape-2 test note).
 	p.Process(watcher.Event{
-		SessionID: childKey,
-		FilePath:  "/home/user/.claude/projects/hash/" + parentID + "/subagents/workflows/wf_x/" + childKey + ".jsonl",
-		Line:      childLine,
-		Bootstrap: true,
+		SessionID:  childKey,
+		FilePath:   "/home/user/.claude/projects/hash/" + parentID + "/subagents/workflows/wf_x/" + childKey + ".jsonl",
+		Line:       childLine,
+		Bootstrap:  true,
+		AgentKind:  "workflow_agent",
+		AgentID:    childKey,
+		WorkflowID: "wf_x",
 	})
 
 	childSess, ok := sessions.Get(childKey)
@@ -634,6 +653,15 @@ func TestParentLinking_Shape3_Workflow(t *testing.T) {
 	}
 	if childSess.ParentID != parentID {
 		t.Errorf("workflow agent ParentID = %q, want %q", childSess.ParentID, parentID)
+	}
+	if childSess.AgentKind != "workflow_agent" {
+		t.Errorf("workflow agent AgentKind = %q, want workflow_agent", childSess.AgentKind)
+	}
+	if childSess.AgentID != childKey {
+		t.Errorf("workflow agent AgentID = %q, want %q", childSess.AgentID, childKey)
+	}
+	if childSess.WorkflowID != "wf_x" {
+		t.Errorf("workflow agent WorkflowID = %q, want wf_x", childSess.WorkflowID)
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -57,6 +57,9 @@ type Session struct {
 	TaskDescription string          `json:"taskDescription"`
 	Version        string           `json:"version,omitempty"`
 	Entrypoint     string           `json:"entrypoint,omitempty"`
+	WorkflowID     string           `json:"workflowId,omitempty"` // wf_<id> grouping all agents of one Claude Code workflow run; empty for non-workflow sessions
+	AgentID        string           `json:"agentId,omitempty"`    // agent-<id> file stem for subagent/workflow rows (== ID); empty for normal sessions
+	AgentKind      string           `json:"agentKind,omitempty"`  // session | subagent | workflow_agent
 	SourceFile     string           `json:"-"` // JSONL file path currently providing events (not serialized)
 	repoSourceRank int              `json:"-"` // resolution-authority rank of RepoID (repo.Source*); runtime-only, not persisted
 }

--- a/internal/store/backfill.go
+++ b/internal/store/backfill.go
@@ -1,0 +1,241 @@
+package store
+
+import (
+	"bufio"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/zxela/claude-monitor/internal/parser"
+)
+
+// backfillMarkerKey is the settings key that records whether the v013 identity
+// backfill has completed successfully. Value "1" means done; "" or absent means
+// the backfill should run on the next startup.
+const backfillMarkerKey = "backfill_v013_done"
+
+// agentFileRe matches a Claude Code agent transcript file base name:
+// "agent-<id>.jsonl". The captured group is the bare agent id.
+var agentFileRe = regexp.MustCompile(`^agent-(.+)\.jsonl$`)
+
+// Agent-kind classifications. These mirror the watcher's package-private
+// constants (internal/watcher/watcher.go:39-44) and pipeline path classification;
+// keep them in sync.
+const (
+	backfillKindSubagent      = "subagent"
+	backfillKindWorkflowAgent = "workflow_agent"
+)
+
+// BackfillResult summarises a v013 identity backfill run.
+type BackfillResult struct {
+	Scanned int // agent-*.jsonl files inspected
+	Updated int // sessions whose UPDATE touched a row
+	Skipped int // files with no matching session row or no parent line
+	Errors  int // recoverable per-file errors (walk continues)
+}
+
+// DefaultBackfillBasePaths returns the well-known locations Claude Code writes
+// session files, with ~/ expanded via os.UserHomeDir. This intentionally keeps
+// its own copy of the list because the watcher's defaultBasePaths/expandHome are
+// unexported; keep it in sync with internal/watcher/watcher.go:46-51.
+func DefaultBackfillBasePaths() []string {
+	paths := []string{
+		"/home/node/.claude/projects",
+		"/root/.claude/projects",
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		paths = append([]string{filepath.Join(home, ".claude", "projects")}, paths...)
+	}
+	return paths
+}
+
+// classifyAgentPath derives (kind, agentID, workflowID) from a transcript file
+// path. It mirrors the watcher's classifyPath / pipeline.parentSessionIDFromPath
+// rules so backfill labels rows identically to live ingestion:
+//
+//	shape 1 normal:        <uuid>.jsonl                                           -> ("",                 "",           "")
+//	shape 2 task subagent: <parent>/subagents/agent-<id>.jsonl                    -> ("subagent",         "agent-<id>", "")
+//	shape 3 workflow:      <parent>/subagents/workflows/wf_<id>/agent-<id>.jsonl  -> ("workflow_agent",   "agent-<id>", "wf_<id>")
+//
+// A non-agent file (no "agent-" prefix) returns kind == "" so callers skip it.
+func classifyAgentPath(filePath string) (kind, agentID, workflowID string) {
+	base := filepath.Base(filePath)
+	m := agentFileRe.FindStringSubmatch(base)
+	if m == nil {
+		return "", "", ""
+	}
+	// agentID is the full "agent-<id>" stem (== ev.SessionID and the session
+	// row's id for shapes 2/3), matching the watcher's classifyPath so backfilled
+	// and live-ingested rows store an identical agent_id value. m[1] is the bare
+	// captured id, used only to confirm the match.
+	_ = m[1]
+	agentID = strings.TrimSuffix(base, ".jsonl")
+
+	// Walk UP looking for a wf_<id> segment and/or a subagents segment.
+	hasSubagents := false
+	wf := ""
+	dir := filepath.Dir(filePath)
+	for dir != "." && dir != string(filepath.Separator) {
+		seg := filepath.Base(dir)
+		if seg == "subagents" {
+			hasSubagents = true
+		}
+		if wf == "" && strings.HasPrefix(seg, "wf_") {
+			wf = seg
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir { // reached filesystem root; stop
+			break
+		}
+		dir = parent
+	}
+	if hasSubagents && wf != "" {
+		return backfillKindWorkflowAgent, agentID, wf
+	}
+	// shape 2, or defensive fallback (agent-* file without a subagents/ ancestor):
+	// classify as a subagent so it is never mistaken for a top-level session.
+	return backfillKindSubagent, agentID, ""
+}
+
+// firstValidEventSessionID reads the first non-empty, parseable JSONL line from
+// the file and returns its in-content sessionId (the parent UUID for shapes 2/3).
+// Blank and unparseable lines are skipped, matching the watcher's trim/skip
+// behaviour. Returns "" if no valid line yields a session id.
+func firstValidEventSessionID(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	sc := bufio.NewScanner(f)
+	// Allow long JSONL lines (default 64K is too small for transcript content).
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		ev, err := parser.ParseLine([]byte(line))
+		if err != nil || ev == nil {
+			continue
+		}
+		if ev.SessionID != "" {
+			return ev.SessionID, nil
+		}
+	}
+	return "", sc.Err()
+}
+
+// RunBackfillV013 walks the given base paths for agent-*.jsonl transcripts and
+// backfills the parent_id / workflow_id / agent_id / agent_kind columns
+// (added by migration 013) for rows that predate Workstream 2 identity stamping
+// or were ingested while those columns were empty.
+//
+// It is idempotent and marker-guarded:
+//   - if !force and the backfill_v013_done marker == "1", it returns early with a
+//     zero-walk result (no reads, no writes).
+//   - the UPDATE only fills empty/blank columns (CASE guards), so re-runs never
+//     clobber values set by live ingestion or a prior run.
+//   - the marker is set ONLY after a fully successful walk, so a mid-walk failure
+//     leaves the marker unset and the next startup retries.
+//
+// It never deletes or truncates rows; it only writes the four identity columns.
+func (d *DB) RunBackfillV013(basePaths []string, force bool) (BackfillResult, error) {
+	var res BackfillResult
+
+	if !force {
+		if v, err := d.GetSetting(backfillMarkerKey); err == nil && v == "1" {
+			// Marker already set: short-circuit with no walk and no writes.
+			return res, nil
+		}
+	}
+
+	// Guarded, additive UPDATE: only fills columns that are currently empty so a
+	// second run (or live ingestion having already populated them) changes nothing.
+	// Depends on migration 013 having added workflow_id/agent_id/agent_kind.
+	const updateSQL = `UPDATE sessions SET
+		parent_id  = CASE WHEN COALESCE(parent_id,'')  = '' THEN ? ELSE parent_id  END,
+		workflow_id = CASE WHEN COALESCE(workflow_id,'') = '' THEN ? ELSE workflow_id END,
+		agent_id   = CASE WHEN COALESCE(agent_id,'')   = '' THEN ? ELSE agent_id   END,
+		agent_kind = CASE WHEN COALESCE(agent_kind,'') = '' THEN ? ELSE agent_kind END
+		WHERE id = ?`
+
+	for _, base := range basePaths {
+		if base == "" {
+			continue
+		}
+		// Silently skip non-existent base paths, mirroring watcher.scanPath.
+		if _, err := os.Stat(base); err != nil {
+			continue
+		}
+
+		walkErr := filepath.WalkDir(base, func(path string, dirent os.DirEntry, err error) error {
+			if err != nil {
+				// Unreadable dir entry: count as a recoverable error and continue.
+				res.Errors++
+				return nil
+			}
+			if dirent.IsDir() {
+				return nil
+			}
+			if !agentFileRe.MatchString(filepath.Base(path)) {
+				return nil
+			}
+
+			res.Scanned++
+
+			kind, agentID, workflowID := classifyAgentPath(path)
+			if kind == "" {
+				// Not an agent transcript shape we backfill.
+				return nil
+			}
+			// The session row id is the "agent-<id>" file stem (ev.SessionID key).
+			id := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+
+			parentID, ferr := firstValidEventSessionID(path)
+			if ferr != nil {
+				res.Errors++
+				return nil
+			}
+			// Guard against self-parenting: the in-content sessionId must differ
+			// from this row's own id to be a real parent link. A missing parent
+			// line is fine — we still write the identity columns (agent_id/kind/
+			// workflow_id) so the row is correctly classified.
+			if parentID == id {
+				parentID = ""
+			}
+
+			result, uerr := d.db.Exec(updateSQL, parentID, workflowID, agentID, kind, id)
+			if uerr != nil {
+				res.Errors++
+				return nil
+			}
+			affected, _ := result.RowsAffected()
+			if affected > 0 {
+				res.Updated++
+				log.Printf("backfill: linked %s parent=%s workflow=%s kind=%s", id, parentID, workflowID, kind)
+			} else {
+				// No row with this id (session not ingested yet) — count Skipped.
+				res.Skipped++
+			}
+			return nil
+		})
+		if walkErr != nil {
+			// A fatal walk error: return WITHOUT setting the marker so we retry.
+			return res, walkErr
+		}
+	}
+
+	// Only set the marker after a fully successful walk (force runs also re-set it
+	// so a subsequent non-forced start short-circuits again).
+	if err := d.SetSetting(backfillMarkerKey, "1"); err != nil {
+		return res, err
+	}
+
+	log.Printf("backfill v013: scanned=%d updated=%d skipped=%d errors=%d",
+		res.Scanned, res.Updated, res.Skipped, res.Errors)
+	return res, nil
+}

--- a/internal/store/backfill_test.go
+++ b/internal/store/backfill_test.go
@@ -143,6 +143,53 @@ func TestRunBackfillV013_OrphanRowLinked(t *testing.T) {
 	}
 }
 
+// TestRunBackfillV013_SessionIDOnLaterLine covers the realistic transcript shape
+// where the first lines carry no in-content sessionId — a leading blank line and a
+// summary line — and an unparseable line appears before the real assistant line.
+// firstValidEventSessionID must skip the blank/summary/garbage lines and link the
+// orphan row using the sessionId from the later line.
+func TestRunBackfillV013_SessionIDOnLaterLine(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	tmp := t.TempDir()
+	parentUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+	path := filepath.Join(tmp, "proj", parentUUID, "subagents", "agent-LATE.jsonl")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	summary := `{"type":"summary","summary":"prior session","leafUuid":"x"}` // parses, no sessionId
+	garbage := `this is not json`                                          // unparseable
+	real := fmt.Sprintf(`{"type":"assistant","sessionId":%q,"isSidechain":true,"uuid":"u2","timestamp":%q,"message":{"role":"assistant","content":"hi"}}`,
+		parentUUID, time.Now().UTC().Format(time.RFC3339))
+	// Leading blank line + no-sessionId summary + garbage, then the real line.
+	content := "\n" + summary + "\n" + garbage + "\n" + real + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	saveOrphan(t, db, "agent-LATE")
+
+	res, err := db.RunBackfillV013([]string{tmp}, false)
+	if err != nil {
+		t.Fatalf("RunBackfillV013 failed: %v", err)
+	}
+	if res.Updated != 1 {
+		t.Errorf("Updated = %d, want 1", res.Updated)
+	}
+
+	a, err := db.GetSession("agent-LATE")
+	if err != nil || a == nil {
+		t.Fatalf("GetSession(agent-LATE): %v / %v", a, err)
+	}
+	if a.ParentID != parentUUID {
+		t.Errorf("ParentID = %q, want %q (sessionId resolved from a later line)", a.ParentID, parentUUID)
+	}
+	if a.AgentKind != backfillKindSubagent {
+		t.Errorf("AgentKind = %q, want %q", a.AgentKind, backfillKindSubagent)
+	}
+}
+
 func TestRunBackfillV013_MarkerPreventsRerun(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)

--- a/internal/store/backfill_test.go
+++ b/internal/store/backfill_test.go
@@ -1,0 +1,303 @@
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/zxela/claude-monitor/internal/session"
+)
+
+// writeAgentFile writes a single-line JSONL transcript at path with the given
+// in-content sessionId, creating parent directories as needed.
+func writeAgentFile(t *testing.T, path, inContentSessionID string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	line := fmt.Sprintf(`{"type":"assistant","sessionId":%q,"isSidechain":true,"uuid":"u1","timestamp":%q,"message":{"role":"assistant","content":"hi"}}`,
+		inContentSessionID, time.Now().UTC().Format(time.RFC3339))
+	if err := os.WriteFile(path, []byte(line+"\n"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// saveOrphan inserts a session row with empty identity columns, simulating a row
+// ingested before Workstream 2 identity stamping.
+func saveOrphan(t *testing.T, db *DB, id string) {
+	t.Helper()
+	if err := db.SaveSession(&session.Session{
+		ID: id, StartedAt: time.Now(), LastActive: time.Now(),
+	}); err != nil {
+		t.Fatalf("SaveSession(%s) failed: %v", id, err)
+	}
+}
+
+func TestClassifyAgentPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name           string
+		path           string
+		wantKind       string
+		wantAgentID    string
+		wantWorkflowID string
+	}{
+		{
+			name:     "shape1 normal session",
+			path:     "/proj/3f2e-uuid.jsonl",
+			wantKind: "",
+		},
+		{
+			name:        "shape2 task subagent",
+			path:        "/proj/parentUUID/subagents/agent-AAA.jsonl",
+			wantKind:    backfillKindSubagent,
+			wantAgentID: "agent-AAA",
+		},
+		{
+			name:           "shape3 workflow agent",
+			path:           "/proj/parentUUID/subagents/workflows/wf_9/agent-BBB.jsonl",
+			wantKind:       backfillKindWorkflowAgent,
+			wantAgentID:    "agent-BBB",
+			wantWorkflowID: "wf_9",
+		},
+		{
+			name:     "non-agent file under subagents",
+			path:     "/proj/parentUUID/subagents/notes.jsonl",
+			wantKind: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind, agentID, workflowID := classifyAgentPath(tt.path)
+			if kind != tt.wantKind {
+				t.Errorf("kind = %q, want %q", kind, tt.wantKind)
+			}
+			if agentID != tt.wantAgentID {
+				t.Errorf("agentID = %q, want %q", agentID, tt.wantAgentID)
+			}
+			if workflowID != tt.wantWorkflowID {
+				t.Errorf("workflowID = %q, want %q", workflowID, tt.wantWorkflowID)
+			}
+		})
+	}
+}
+
+func TestRunBackfillV013_OrphanRowLinked(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	tmp := t.TempDir()
+	parentUUID := "11111111-2222-3333-4444-555555555555"
+
+	// shape-2 subagent and shape-3 workflow-agent transcripts on disk.
+	shape2 := filepath.Join(tmp, "proj", parentUUID, "subagents", "agent-AAA.jsonl")
+	shape3 := filepath.Join(tmp, "proj", parentUUID, "subagents", "workflows", "wf_123", "agent-BBB.jsonl")
+	writeAgentFile(t, shape2, parentUUID)
+	writeAgentFile(t, shape3, parentUUID)
+
+	// Pre-insert orphan sessions keyed by the agent-<id> stem.
+	saveOrphan(t, db, "agent-AAA")
+	saveOrphan(t, db, "agent-BBB")
+
+	res, err := db.RunBackfillV013([]string{tmp}, false)
+	if err != nil {
+		t.Fatalf("RunBackfillV013 failed: %v", err)
+	}
+	if res.Scanned != 2 {
+		t.Errorf("Scanned = %d, want 2", res.Scanned)
+	}
+	if res.Updated != 2 {
+		t.Errorf("Updated = %d, want 2", res.Updated)
+	}
+
+	a, err := db.GetSession("agent-AAA")
+	if err != nil || a == nil {
+		t.Fatalf("GetSession(agent-AAA): %v / %v", a, err)
+	}
+	if a.ParentID != parentUUID {
+		t.Errorf("agent-AAA ParentID = %q, want %q", a.ParentID, parentUUID)
+	}
+	if a.AgentID != "agent-AAA" {
+		t.Errorf("agent-AAA AgentID = %q, want agent-AAA", a.AgentID)
+	}
+	if a.AgentKind != backfillKindSubagent {
+		t.Errorf("agent-AAA AgentKind = %q, want %q", a.AgentKind, backfillKindSubagent)
+	}
+	if a.WorkflowID != "" {
+		t.Errorf("agent-AAA WorkflowID = %q, want empty", a.WorkflowID)
+	}
+
+	b, err := db.GetSession("agent-BBB")
+	if err != nil || b == nil {
+		t.Fatalf("GetSession(agent-BBB): %v / %v", b, err)
+	}
+	if b.ParentID != parentUUID {
+		t.Errorf("agent-BBB ParentID = %q, want %q", b.ParentID, parentUUID)
+	}
+	if b.AgentKind != backfillKindWorkflowAgent {
+		t.Errorf("agent-BBB AgentKind = %q, want %q", b.AgentKind, backfillKindWorkflowAgent)
+	}
+	if b.WorkflowID != "wf_123" {
+		t.Errorf("agent-BBB WorkflowID = %q, want wf_123", b.WorkflowID)
+	}
+}
+
+func TestRunBackfillV013_MarkerPreventsRerun(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	tmp := t.TempDir()
+	parentUUID := "aaaa-parent"
+	shape2 := filepath.Join(tmp, "proj", parentUUID, "subagents", "agent-AAA.jsonl")
+	writeAgentFile(t, shape2, parentUUID)
+	saveOrphan(t, db, "agent-AAA")
+
+	// First run sets the marker.
+	if _, err := db.RunBackfillV013([]string{tmp}, false); err != nil {
+		t.Fatalf("first RunBackfillV013 failed: %v", err)
+	}
+
+	// Mutate the row to a sentinel parent so we can detect a (wrongful) rewrite.
+	if _, err := db.db.Exec(`UPDATE sessions SET parent_id = 'SENTINEL' WHERE id = 'agent-AAA'`); err != nil {
+		t.Fatalf("sentinel update failed: %v", err)
+	}
+
+	res, err := db.RunBackfillV013([]string{tmp}, false)
+	if err != nil {
+		t.Fatalf("second RunBackfillV013 failed: %v", err)
+	}
+	if res.Scanned != 0 {
+		t.Errorf("Scanned = %d, want 0 (marker should short-circuit the walk)", res.Scanned)
+	}
+
+	a, err := db.GetSession("agent-AAA")
+	if err != nil || a == nil {
+		t.Fatalf("GetSession(agent-AAA): %v / %v", a, err)
+	}
+	if a.ParentID != "SENTINEL" {
+		t.Errorf("ParentID = %q, want SENTINEL unchanged (marker short-circuit)", a.ParentID)
+	}
+}
+
+func TestRunBackfillV013_Idempotent_NoClobber(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	tmp := t.TempDir()
+	parentUUID := "bbbb-parent"
+	shape2 := filepath.Join(tmp, "proj", parentUUID, "subagents", "agent-AAA.jsonl")
+	writeAgentFile(t, shape2, parentUUID)
+	saveOrphan(t, db, "agent-AAA")
+
+	// First run populates the identity columns.
+	if _, err := db.RunBackfillV013([]string{tmp}, false); err != nil {
+		t.Fatalf("first RunBackfillV013 failed: %v", err)
+	}
+	before, err := db.GetSession("agent-AAA")
+	if err != nil || before == nil {
+		t.Fatalf("GetSession before: %v / %v", before, err)
+	}
+
+	// Force a second run even though the marker is set. The walk must run, but the
+	// CASE guards mean already-populated columns are preserved.
+	res, err := db.RunBackfillV013([]string{tmp}, true)
+	if err != nil {
+		t.Fatalf("forced RunBackfillV013 failed: %v", err)
+	}
+	if res.Scanned != 1 {
+		t.Errorf("Scanned = %d, want 1 (force=true must walk even with marker set)", res.Scanned)
+	}
+
+	after, err := db.GetSession("agent-AAA")
+	if err != nil || after == nil {
+		t.Fatalf("GetSession after: %v / %v", after, err)
+	}
+	if after.ParentID != before.ParentID || after.WorkflowID != before.WorkflowID ||
+		after.AgentID != before.AgentID || after.AgentKind != before.AgentKind {
+		t.Errorf("identity columns changed on re-run: before=%+v after=%+v", before, after)
+	}
+}
+
+func TestRunBackfillV013_NoMatchingFilesNoError(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	tmp := t.TempDir()
+	// Only a normal shape-1 transcript; no agent-*.jsonl files.
+	normal := filepath.Join(tmp, "proj", "plain-uuid.jsonl")
+	writeAgentFile(t, normal, "plain-uuid")
+
+	res, err := db.RunBackfillV013([]string{tmp}, false)
+	if err != nil {
+		t.Fatalf("RunBackfillV013 failed: %v", err)
+	}
+	if res.Scanned != 0 {
+		t.Errorf("Scanned = %d, want 0", res.Scanned)
+	}
+	if res.Updated != 0 {
+		t.Errorf("Updated = %d, want 0", res.Updated)
+	}
+	if v, err := db.GetSetting(backfillMarkerKey); err != nil || v != "1" {
+		t.Errorf("marker = %q (err %v), want \"1\"", v, err)
+	}
+}
+
+func TestRunBackfillV013_MissingBasePathSkipped(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	res, err := db.RunBackfillV013([]string{missing}, false)
+	if err != nil {
+		t.Fatalf("RunBackfillV013 should silently skip missing path, got: %v", err)
+	}
+	if res.Scanned != 0 || res.Errors != 0 {
+		t.Errorf("Scanned=%d Errors=%d, want 0/0", res.Scanned, res.Errors)
+	}
+}
+
+func TestRunBackfillV013_SelfParentGuard(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+	tmp := t.TempDir()
+	// in-content sessionId equals the file stem "agent-CCC" -> no self-parenting.
+	shape2 := filepath.Join(tmp, "proj", "someparent", "subagents", "agent-CCC.jsonl")
+	writeAgentFile(t, shape2, "agent-CCC")
+	saveOrphan(t, db, "agent-CCC")
+
+	if _, err := db.RunBackfillV013([]string{tmp}, false); err != nil {
+		t.Fatalf("RunBackfillV013 failed: %v", err)
+	}
+	c, err := db.GetSession("agent-CCC")
+	if err != nil || c == nil {
+		t.Fatalf("GetSession(agent-CCC): %v / %v", c, err)
+	}
+	if c.ParentID != "" {
+		t.Errorf("ParentID = %q, want empty (self-parent guard)", c.ParentID)
+	}
+	// Identity columns are still filled even with no parent link.
+	if c.AgentKind != backfillKindSubagent || c.AgentID != "agent-CCC" {
+		t.Errorf("identity not filled: kind=%q id=%q", c.AgentKind, c.AgentID)
+	}
+}
+
+func TestDefaultBackfillBasePaths(t *testing.T) {
+	t.Parallel()
+	paths := DefaultBackfillBasePaths()
+	if len(paths) < 2 {
+		t.Fatalf("expected at least the two container paths, got %v", paths)
+	}
+	// The two well-known container locations are always present.
+	want := map[string]bool{
+		"/home/node/.claude/projects": false,
+		"/root/.claude/projects":      false,
+	}
+	for _, p := range paths {
+		if _, ok := want[p]; ok {
+			want[p] = true
+		}
+	}
+	for p, seen := range want {
+		if !seen {
+			t.Errorf("missing well-known path %q in %v", p, paths)
+		}
+	}
+}

--- a/internal/store/migrations/013_workflow_columns.go
+++ b/internal/store/migrations/013_workflow_columns.go
@@ -1,0 +1,35 @@
+package migrations
+
+import "database/sql"
+
+func init() {
+	Register(13, Migration{
+		Name: "workflow_columns",
+		Up: func(tx *sql.Tx) error {
+			for _, stmt := range []string{
+				`ALTER TABLE sessions ADD COLUMN workflow_id TEXT`,
+				`ALTER TABLE sessions ADD COLUMN agent_id TEXT`,
+				`ALTER TABLE sessions ADD COLUMN agent_kind TEXT`,
+				`CREATE INDEX idx_sessions_workflow ON sessions(workflow_id)`,
+			} {
+				if _, err := tx.Exec(stmt); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Down: func(tx *sql.Tx) error {
+			for _, stmt := range []string{
+				`DROP INDEX IF EXISTS idx_sessions_workflow`,
+				`ALTER TABLE sessions DROP COLUMN workflow_id`,
+				`ALTER TABLE sessions DROP COLUMN agent_id`,
+				`ALTER TABLE sessions DROP COLUMN agent_kind`,
+			} {
+				if _, err := tx.Exec(stmt); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	})
+}

--- a/internal/store/migrations/registry_test.go
+++ b/internal/store/migrations/registry_test.go
@@ -250,3 +250,87 @@ func TestFailedMigration_RollsBack(t *testing.T) {
 		t.Errorf("expected version 1 after failed migration 2, got %d", v)
 	}
 }
+
+// columnExists reports whether a column is present on a table.
+func columnExists(t *testing.T, db *sql.DB, table, col string) bool {
+	t.Helper()
+	rows, err := db.Query(`SELECT name FROM pragma_table_info(?)`, table)
+	if err != nil {
+		t.Fatalf("pragma_table_info(%s): %v", table, err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatalf("scan column: %v", err)
+		}
+		if name == col {
+			return true
+		}
+	}
+	return false
+}
+
+// indexExists reports whether a named index exists.
+func indexExists(t *testing.T, db *sql.DB, name string) bool {
+	t.Helper()
+	var n int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='index' AND name=?`, name).Scan(&n); err != nil {
+		t.Fatalf("index lookup: %v", err)
+	}
+	return n > 0
+}
+
+// TestMigration013_DownRoundTrip runs the REAL registry to head, rolls back past
+// migration 013 (workflow columns), asserts the columns + index are dropped, then
+// re-applies to head — verifying 013's Down is correct and reversible. It rolls
+// back to version 12 generically so it stays valid as later migrations stack on 013.
+func TestMigration013_DownRoundTrip(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("RunUp: %v", err)
+	}
+	for _, col := range []string{"workflow_id", "agent_id", "agent_kind"} {
+		if !columnExists(t, db, "sessions", col) {
+			t.Fatalf("after RunUp: sessions.%s missing", col)
+		}
+	}
+	if !indexExists(t, db, "idx_sessions_workflow") {
+		t.Fatal("after RunUp: idx_sessions_workflow missing")
+	}
+
+	// Roll back everything above migration 12 (013 and anything stacked on it).
+	for {
+		v, err := GetVersion(db)
+		if err != nil {
+			t.Fatalf("GetVersion: %v", err)
+		}
+		if v <= 12 {
+			break
+		}
+		if _, err := RunDown(db); err != nil {
+			t.Fatalf("RunDown from v%d: %v", v, err)
+		}
+	}
+
+	// 013's columns and index must be gone.
+	for _, col := range []string{"workflow_id", "agent_id", "agent_kind"} {
+		if columnExists(t, db, "sessions", col) {
+			t.Errorf("after rollback past 013: sessions.%s should be dropped", col)
+		}
+	}
+	if indexExists(t, db, "idx_sessions_workflow") {
+		t.Error("after rollback past 013: idx_sessions_workflow should be dropped")
+	}
+
+	// Re-apply to head — 013 (and anything above) must cleanly re-create the columns.
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("re-RunUp after rollback: %v", err)
+	}
+	if !columnExists(t, db, "sessions", "workflow_id") {
+		t.Error("after re-RunUp: workflow_id not restored")
+	}
+	if !indexExists(t, db, "idx_sessions_workflow") {
+		t.Error("after re-RunUp: idx_sessions_workflow not restored")
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -45,7 +45,8 @@ const sessionSelectCols = `id, COALESCE(repo_id,''), COALESCE(parent_id,''), COA
 	COALESCE(model,''), COALESCE(started_at,''), COALESCE(ended_at,''),
 	total_cost, input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
 	message_count, event_count, error_count,
-	COALESCE(version,''), COALESCE(entrypoint,'')`
+	COALESCE(version,''), COALESCE(entrypoint,''),
+	COALESCE(workflow_id,''), COALESCE(agent_id,''), COALESCE(agent_kind,'')`
 
 // SessionRow represents a session as stored in the database.
 type SessionRow struct {
@@ -69,6 +70,9 @@ type SessionRow struct {
 	ErrorCount          int     `json:"errorCount"`
 	Version             string  `json:"version,omitempty"`
 	Entrypoint          string  `json:"entrypoint,omitempty"`
+	WorkflowID          string  `json:"workflowId,omitempty"`
+	AgentID             string  `json:"agentId,omitempty"`
+	AgentKind           string  `json:"agentKind,omitempty"`
 }
 
 // ToSession converts a SessionRow to a session.Session with default runtime fields.
@@ -92,6 +96,9 @@ func (r *SessionRow) ToSession() *session.Session {
 		TaskDescription:     r.TaskDescription,
 		Version:             r.Version,
 		Entrypoint:          r.Entrypoint,
+		WorkflowID:          r.WorkflowID,
+		AgentID:             r.AgentID,
+		AgentKind:           r.AgentKind,
 		IsActive:            false,
 		Status:              "idle",
 		CostRate:            0,
@@ -347,8 +354,8 @@ func (d *DB) SaveSession(s *session.Session) error {
 		(id, repo_id, parent_id, session_name, task_description, cwd, branch, model,
 		 started_at, ended_at, total_cost, input_tokens, output_tokens,
 		 cache_read_tokens, cache_creation_tokens, message_count, event_count, error_count,
-		 version, entrypoint)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 version, entrypoint, workflow_id, agent_id, agent_kind)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 		 repo_id=excluded.repo_id,
 		 parent_id=excluded.parent_id,
@@ -368,13 +375,17 @@ func (d *DB) SaveSession(s *session.Session) error {
 		 event_count=excluded.event_count,
 		 error_count=excluded.error_count,
 		 version=excluded.version,
-		 entrypoint=excluded.entrypoint`,
+		 entrypoint=excluded.entrypoint,
+		 workflow_id=excluded.workflow_id,
+		 agent_id=excluded.agent_id,
+		 agent_kind=excluded.agent_kind`,
 		s.ID, s.RepoID, s.ParentID, s.SessionName, s.TaskDescription,
 		s.CWD, s.GitBranch, s.Model, startedAt, endedAt,
 		s.TotalCost, s.InputTokens, s.OutputTokens,
 		s.CacheReadTokens, s.CacheCreationTokens,
 		s.MessageCount, s.EventCount, s.ErrorCount,
 		s.Version, s.Entrypoint,
+		s.WorkflowID, s.AgentID, s.AgentKind,
 	)
 	if err != nil {
 		return fmt.Errorf("SaveSession: %w", err)
@@ -402,8 +413,8 @@ func (d *DB) FlushSessions(sessions []*session.Session) error {
 		(id, repo_id, parent_id, session_name, task_description, cwd, branch, model,
 		 started_at, ended_at, total_cost, input_tokens, output_tokens,
 		 cache_read_tokens, cache_creation_tokens, message_count, event_count, error_count,
-		 version, entrypoint)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 version, entrypoint, workflow_id, agent_id, agent_kind)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON CONFLICT(id) DO UPDATE SET
 		 repo_id=excluded.repo_id,
 		 parent_id=excluded.parent_id,
@@ -423,7 +434,10 @@ func (d *DB) FlushSessions(sessions []*session.Session) error {
 		 event_count=excluded.event_count,
 		 error_count=excluded.error_count,
 		 version=excluded.version,
-		 entrypoint=excluded.entrypoint`)
+		 entrypoint=excluded.entrypoint,
+		 workflow_id=excluded.workflow_id,
+		 agent_id=excluded.agent_id,
+		 agent_kind=excluded.agent_kind`)
 	if err != nil {
 		return fmt.Errorf("FlushSessions prepare session: %w", err)
 	}
@@ -453,6 +467,7 @@ func (d *DB) FlushSessions(sessions []*session.Session) error {
 			s.CacheReadTokens, s.CacheCreationTokens,
 			s.MessageCount, s.EventCount, s.ErrorCount,
 			s.Version, s.Entrypoint,
+			s.WorkflowID, s.AgentID, s.AgentKind,
 		); err != nil {
 			return fmt.Errorf("FlushSessions save %s: %w", s.ID, err)
 		}
@@ -550,6 +565,55 @@ func (d *DB) ListSessionsByRepo(repoID string, limit, offset int) ([]SessionRow,
 	return scanSessionRows(rows)
 }
 
+// ListSessionsByWorkflow returns sessions belonging to a workflow, ordered by ended_at descending.
+func (d *DB) ListSessionsByWorkflow(workflowID string, limit, offset int) ([]SessionRow, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	rows, err := d.db.Query(`SELECT `+sessionSelectCols+`
+		FROM sessions WHERE workflow_id = ? ORDER BY ended_at DESC LIMIT ? OFFSET ?`, workflowID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanSessionRows(rows)
+}
+
+// WorkflowRow is a per-workflow aggregate: one row per distinct workflow_id.
+type WorkflowRow struct {
+	WorkflowID string  `json:"workflowId"`
+	AgentCount int     `json:"agentCount"`
+	TotalCost  float64 `json:"totalCost"`
+	LastActive string  `json:"lastActive"`
+}
+
+// ListWorkflows returns one aggregate row per distinct workflow_id, ordered by
+// most-recent activity. Cost is summed across every agent row in the workflow,
+// so a workflow's spend is counted exactly once across its agents.
+//
+// workflow_id is nullable (migration 013 adds it as plain TEXT, no DEFAULT ''),
+// so the non-empty filter uses COALESCE(workflow_id,'') <> ''.
+func (d *DB) ListWorkflows() ([]WorkflowRow, error) {
+	rows, err := d.db.Query(`SELECT workflow_id, COUNT(*), COALESCE(SUM(total_cost),0), COALESCE(MAX(ended_at),'')
+		FROM sessions WHERE COALESCE(workflow_id,'') <> '' GROUP BY workflow_id ORDER BY MAX(ended_at) DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var result []WorkflowRow
+	for rows.Next() {
+		var wr WorkflowRow
+		if err := rows.Scan(&wr.WorkflowID, &wr.AgentCount, &wr.TotalCost, &wr.LastActive); err != nil {
+			return nil, err
+		}
+		result = append(result, wr)
+	}
+	return result, rows.Err()
+}
+
 // AggregateStatsByRepo returns aggregate statistics for a single repo.
 func (d *DB) AggregateStatsByRepo(repoID string) (*AggregateResult, error) {
 	r := &AggregateResult{
@@ -626,6 +690,7 @@ func scanSessionRows(rows *sql.Rows) ([]SessionRow, error) {
 			&r.CacheReadTokens, &r.CacheCreationTokens,
 			&r.MessageCount, &r.EventCount, &r.ErrorCount,
 			&r.Version, &r.Entrypoint,
+			&r.WorkflowID, &r.AgentID, &r.AgentKind,
 		); err != nil {
 			return result, err
 		}
@@ -634,7 +699,12 @@ func scanSessionRows(rows *sql.Rows) ([]SessionRow, error) {
 	return result, rows.Err()
 }
 
-// AggregateStats returns aggregate statistics. Includes ALL sessions (no parent filter).
+// AggregateStats returns lifetime aggregate statistics across ALL session rows
+// (parents and their workflow/subagent children). Cost and tokens are summed
+// exactly once because each row carries only its own spend. SessionCount here
+// counts every row (a workflow's agents are individual rows); contrast TrendData,
+// whose SessionCount counts only top-level sessions (parent_id empty) while still
+// summing cost/tokens across all rows. Both definitions count each dollar once.
 func (d *DB) AggregateStats(since time.Time) (*AggregateResult, error) {
 	r := &AggregateResult{
 		CostByModel: make(map[string]float64),
@@ -699,12 +769,18 @@ func (d *DB) AggregateStats(since time.Time) (*AggregateResult, error) {
 }
 
 // trendParams holds the parsed query parameters shared across TrendData helpers.
+//
+// windowWhere = all rows in window (used for cost/token SUMs, so each dollar is
+// counted exactly once where it was incurred — including workflow/subagent child rows).
+// where = top-level sessions only (windowWhere + parent_id empty); used for the
+// COUNT/AVG/percentile distributions, which describe top-level sessions.
 type trendParams struct {
-	dateFmt  string
-	interval string
-	where    string
-	args     []interface{}
-	repoID   string
+	dateFmt     string
+	interval    string
+	windowWhere string
+	where       string
+	args        []interface{}
+	repoID      string
 }
 
 // TrendData returns time-bucketed analytics for the given window and optional repo filter.
@@ -726,14 +802,18 @@ func (d *DB) TrendData(window string, repoID string) (*TrendResult, error) {
 		return nil, fmt.Errorf("invalid window: %s", window)
 	}
 
-	where := fmt.Sprintf("started_at >= datetime('now', '%s') AND (parent_id IS NULL OR parent_id = '')", interval)
+	// windowWhere matches ALL rows in the window (for cost/token SUMs, counted
+	// once). where additionally restricts to top-level sessions (parent_id empty)
+	// for COUNT/AVG/percentile distributions.
+	windowWhere := fmt.Sprintf("started_at >= datetime('now', '%s')", interval)
 	var args []interface{}
 	if repoID != "" {
-		where += " AND repo_id = ?"
+		windowWhere += " AND repo_id = ?"
 		args = append(args, repoID)
 	}
+	where := windowWhere + " AND (parent_id IS NULL OR parent_id = '')"
 
-	p := &trendParams{dateFmt: dateFmt, interval: interval, where: where, args: args, repoID: repoID}
+	p := &trendParams{dateFmt: dateFmt, interval: interval, windowWhere: windowWhere, where: where, args: args, repoID: repoID}
 
 	buckets, err := d.trendBuckets(p)
 	if err != nil {
@@ -778,13 +858,20 @@ func (d *DB) TrendData(window string, repoID string) (*TrendResult, error) {
 }
 
 // trendBuckets queries time-bucketed session aggregates.
+//
+// Cost and tokens are summed over ALL rows in the window (p.windowWhere) so each
+// dollar is counted exactly once, including workflow/subagent child rows. The
+// SessionCount and AvgSessionCost are computed via CASE over top-level sessions
+// only (parent_id empty), keeping those distributions about top-level sessions.
 func (d *DB) trendBuckets(p *trendParams) ([]TrendBucket, error) {
 	bucketQuery := fmt.Sprintf(`SELECT strftime('%s', started_at) AS bucket,
 		COALESCE(SUM(total_cost),0), COALESCE(SUM(input_tokens),0), COALESCE(SUM(output_tokens),0),
 		COALESCE(SUM(cache_read_tokens),0), COALESCE(SUM(cache_creation_tokens),0),
-		COUNT(*), COALESCE(AVG(total_cost),0)
+		COALESCE(SUM(CASE WHEN parent_id IS NULL OR parent_id = '' THEN 1 ELSE 0 END),0),
+		COALESCE(SUM(CASE WHEN parent_id IS NULL OR parent_id = '' THEN total_cost ELSE 0 END)
+			/ NULLIF(SUM(CASE WHEN parent_id IS NULL OR parent_id = '' THEN 1 ELSE 0 END),0),0)
 		FROM sessions WHERE %s
-		GROUP BY bucket ORDER BY bucket`, p.dateFmt, p.where)
+		GROUP BY bucket ORDER BY bucket`, p.dateFmt, p.windowWhere)
 
 	rows, err := d.db.Query(bucketQuery, p.args...)
 	if err != nil {
@@ -855,17 +942,22 @@ func (d *DB) trendPercentiles(p *trendParams, buckets []TrendBucket) error {
 }
 
 // trendByRepo queries cost/token breakdown grouped by repository.
+//
+// Cost and tokens are summed over ALL rows in the window (counted once,
+// including child rows). The session count is over top-level sessions only
+// (parent_id empty) via CASE. For shapes 2/3 children share the parent's
+// repo_id (set in pipeline), so repo attribution stays stable.
 func (d *DB) trendByRepo(p *trendParams) ([]RepoTrend, error) {
-	repoWhere := fmt.Sprintf("s.started_at >= datetime('now', '%s') AND (s.parent_id IS NULL OR s.parent_id = '')", p.interval)
+	repoWindowWhere := fmt.Sprintf("s.started_at >= datetime('now', '%s')", p.interval)
 	if p.repoID != "" {
-		repoWhere += " AND s.repo_id = ?"
+		repoWindowWhere += " AND s.repo_id = ?"
 	}
 	repoQuery := fmt.Sprintf(`SELECT s.repo_id, COALESCE(r.name,''), COALESCE(SUM(s.total_cost),0),
 		COALESCE(SUM(s.input_tokens + s.output_tokens + s.cache_read_tokens + s.cache_creation_tokens),0),
-		COUNT(*)
+		COALESCE(SUM(CASE WHEN s.parent_id IS NULL OR s.parent_id = '' THEN 1 ELSE 0 END),0)
 		FROM sessions s JOIN repos r ON r.id = s.repo_id
 		WHERE %s AND s.repo_id != ''
-		GROUP BY r.id ORDER BY SUM(s.total_cost) DESC`, repoWhere)
+		GROUP BY r.id ORDER BY SUM(s.total_cost) DESC`, repoWindowWhere)
 
 	repoRows, err := d.db.Query(repoQuery, p.args...)
 	if err != nil {
@@ -891,12 +983,17 @@ func (d *DB) trendByRepo(p *trendParams) ([]RepoTrend, error) {
 }
 
 // trendByModel queries cost/token breakdown grouped by model.
+//
+// Cost and tokens are summed over ALL rows in the window (p.windowWhere),
+// counted once. This now includes child (e.g. subagent on a different model)
+// spend, which is desired since a workflow can mix models. The session count is
+// over top-level sessions only (parent_id empty) via CASE.
 func (d *DB) trendByModel(p *trendParams) ([]ModelTrend, error) {
 	modelQuery := fmt.Sprintf(`SELECT COALESCE(model,'unknown'), COALESCE(SUM(total_cost),0),
 		COALESCE(SUM(input_tokens + output_tokens + cache_read_tokens + cache_creation_tokens),0),
-		COUNT(*)
+		COALESCE(SUM(CASE WHEN parent_id IS NULL OR parent_id = '' THEN 1 ELSE 0 END),0)
 		FROM sessions WHERE %s AND model != ''
-		GROUP BY model ORDER BY SUM(total_cost) DESC`, p.where)
+		GROUP BY model ORDER BY SUM(total_cost) DESC`, p.windowWhere)
 
 	modelRows, err := d.db.Query(modelQuery, p.args...)
 	if err != nil {
@@ -1115,6 +1212,38 @@ func (d *DB) ListEvents(sessionID string, limit, offset int) ([]EventRow, error)
 		WHERE e.session_id = ?
 		ORDER BY e.timestamp ASC
 		LIMIT ? OFFSET ?`, sessionID, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	return scanEventRows(rows)
+}
+
+// ListReplayEvents returns events for a session plus all events belonging to its
+// direct children (subagents / workflow agents linked via parent_id), merged in
+// chronological order. Used by the replay endpoint so a parent (or workflow root)
+// plays back as a single timeline.
+//
+// parent_id is the Phase-1 in-content parentage link, so selecting children by
+// parent_id covers both shape-2 subagents and shape-3 workflow agents without a
+// separate workflow join. A leaf session with no children returns exactly the
+// same rows as ListEvents (the subquery matches nothing), so this is backward
+// compatible. The secondary `e.id ASC` sort keeps the timeline deterministic
+// when parent and child events share a timestamp.
+func (d *DB) ListReplayEvents(sessionID string, limit, offset int) ([]EventRow, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	rows, err := d.db.Query(`SELECT `+eventSelectCols+`,
+		COALESCE(ec.content,''), ec.compressed
+		FROM events e LEFT JOIN event_content ec ON ec.event_id = e.id
+		WHERE e.session_id = ?
+		   OR e.session_id IN (SELECT id FROM sessions WHERE parent_id = ?)
+		ORDER BY e.timestamp ASC, e.id ASC
+		LIMIT ? OFFSET ?`, sessionID, sessionID, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -31,6 +31,45 @@ func TestOpen_CreatesDatabase(t *testing.T) {
 	openTestDB(t) // just verifying it doesn't panic/error
 }
 
+// TestMigration013_WorkflowColumns verifies migration 013 added the workflow
+// identity columns and the workflow index to the sessions table.
+func TestMigration013_WorkflowColumns(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	cols := make(map[string]bool)
+	rows, err := db.db.Query(`PRAGMA table_info(sessions)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info failed: %v", err)
+	}
+	for rows.Next() {
+		var cid int
+		var name, ctype string
+		var notnull, pk int
+		var dflt interface{}
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			rows.Close()
+			t.Fatalf("scan table_info: %v", err)
+		}
+		cols[name] = true
+	}
+	rows.Close()
+	for _, want := range []string{"workflow_id", "agent_id", "agent_kind"} {
+		if !cols[want] {
+			t.Errorf("sessions table missing column %q", want)
+		}
+	}
+
+	var idxName string
+	err = db.db.QueryRow(`SELECT name FROM sqlite_master WHERE type='index' AND name='idx_sessions_workflow'`).Scan(&idxName)
+	if err != nil {
+		t.Fatalf("expected idx_sessions_workflow index to exist: %v", err)
+	}
+	if idxName != "idx_sessions_workflow" {
+		t.Errorf("index name: got %q, want idx_sessions_workflow", idxName)
+	}
+}
+
 func TestUpsertRepo(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
@@ -246,6 +285,103 @@ func TestAggregateStats_IncludesChildren(t *testing.T) {
 	}
 	if agg.InputTokens != 250 {
 		t.Errorf("InputTokens: got %d, want 250", agg.InputTokens)
+	}
+}
+
+func TestSession_WorkflowColumnsRoundTrip(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now()
+	sess := &session.Session{
+		ID:         "agent-abc",
+		WorkflowID: "wf_xyz",
+		AgentID:    "agent-abc",
+		AgentKind:  "workflow_agent",
+		ParentID:   "parent-1",
+		TotalCost:  0.42,
+		StartedAt:  now.Add(-5 * time.Minute),
+		LastActive: now,
+	}
+	if err := db.SaveSession(sess); err != nil {
+		t.Fatalf("SaveSession failed: %v", err)
+	}
+
+	got, err := db.GetSession("agent-abc")
+	if err != nil {
+		t.Fatalf("GetSession failed: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("GetSession returned nil")
+	}
+	if got.WorkflowID != "wf_xyz" {
+		t.Errorf("WorkflowID: got %q, want %q", got.WorkflowID, "wf_xyz")
+	}
+	if got.AgentID != "agent-abc" {
+		t.Errorf("AgentID: got %q, want %q", got.AgentID, "agent-abc")
+	}
+	if got.AgentKind != "workflow_agent" {
+		t.Errorf("AgentKind: got %q, want %q", got.AgentKind, "workflow_agent")
+	}
+
+	// Also verify ToSession propagates the fields onto the runtime session.
+	rt := got.ToSession()
+	if rt.WorkflowID != "wf_xyz" || rt.AgentID != "agent-abc" || rt.AgentKind != "workflow_agent" {
+		t.Errorf("ToSession identity: got (%q,%q,%q), want (wf_xyz,agent-abc,workflow_agent)",
+			rt.WorkflowID, rt.AgentID, rt.AgentKind)
+	}
+}
+
+func TestListSessionsByWorkflow(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now()
+	// Two sessions in workflow wf_a (a parent and a child) plus one unrelated.
+	sessions := []*session.Session{
+		{
+			ID: "parent-1", WorkflowID: "wf_a", AgentKind: "session",
+			TotalCost: 1.00, StartedAt: now.Add(-10 * time.Minute), LastActive: now.Add(-2 * time.Minute),
+		},
+		{
+			ID: "agent-1", WorkflowID: "wf_a", AgentID: "agent-1", AgentKind: "workflow_agent",
+			ParentID: "parent-1", TotalCost: 0.50, StartedAt: now.Add(-9 * time.Minute), LastActive: now,
+		},
+		{
+			ID: "other-1", WorkflowID: "", AgentKind: "session",
+			TotalCost: 3.00, StartedAt: now.Add(-8 * time.Minute), LastActive: now,
+		},
+	}
+	for _, s := range sessions {
+		if err := db.SaveSession(s); err != nil {
+			t.Fatalf("SaveSession(%s) failed: %v", s.ID, err)
+		}
+	}
+
+	rows, err := db.ListSessionsByWorkflow("wf_a", 50, 0)
+	if err != nil {
+		t.Fatalf("ListSessionsByWorkflow failed: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows for wf_a, got %d", len(rows))
+	}
+	for _, r := range rows {
+		if r.WorkflowID != "wf_a" {
+			t.Errorf("row %s WorkflowID: got %q, want wf_a", r.ID, r.WorkflowID)
+		}
+	}
+	// Ordered by ended_at descending: agent-1 (ended now) before parent-1.
+	if rows[0].ID != "agent-1" {
+		t.Errorf("expected agent-1 first (most recent ended_at), got %s", rows[0].ID)
+	}
+
+	// Empty workflow returns nothing.
+	none, err := db.ListSessionsByWorkflow("wf_missing", 50, 0)
+	if err != nil {
+		t.Fatalf("ListSessionsByWorkflow(missing) failed: %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("expected 0 rows for missing workflow, got %d", len(none))
 	}
 }
 
@@ -810,6 +946,122 @@ func TestTrendByModel(t *testing.T) {
 	}
 }
 
+// TestTrendByRepo_CountsChildCostOnce proves the cost-once invariant on the
+// per-repo breakdown: a child row's spend is summed into its repo (counted once,
+// since each row carries only its own cost) while the child is NOT counted as a
+// top-level session. A regression that re-added a parent_id filter to the cost
+// SUM would undercount this repo's spend and fail here.
+func TestTrendByRepo_CountsChildCostOnce(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now()
+	if err := db.UpsertRepo(&repo.Repo{ID: "repo-a", Name: "repo-a"}); err != nil {
+		t.Fatalf("UpsertRepo failed: %v", err)
+	}
+	// Parent: top-level session in repo-a, cost 5.00.
+	if err := db.SaveSession(&session.Session{
+		ID: "parent-1", RepoID: "repo-a", TotalCost: 5.00, InputTokens: 500,
+		StartedAt: now.Add(-2 * time.Hour), LastActive: now,
+		Model: "claude-sonnet-4-6",
+	}); err != nil {
+		t.Fatalf("SaveSession(parent) failed: %v", err)
+	}
+	// Child: workflow agent in the same repo (children inherit parent repo_id),
+	// cost 1.00, parent_id set so it is not a top-level session.
+	if err := db.SaveSession(&session.Session{
+		ID: "child-1", RepoID: "repo-a", ParentID: "parent-1", TotalCost: 1.00, InputTokens: 100,
+		StartedAt: now.Add(-1 * time.Hour), LastActive: now,
+		Model: "claude-sonnet-4-6",
+	}); err != nil {
+		t.Fatalf("SaveSession(child) failed: %v", err)
+	}
+
+	result, err := db.TrendData("7d", "")
+	if err != nil {
+		t.Fatalf("TrendData failed: %v", err)
+	}
+
+	if len(result.ByRepo) != 1 {
+		t.Fatalf("expected 1 repo trend, got %d", len(result.ByRepo))
+	}
+	rt := result.ByRepo[0]
+	if rt.RepoID != "repo-a" {
+		t.Errorf("repo: got %q, want repo-a", rt.RepoID)
+	}
+	// Cost summed across parent + child, counted once: 5.00 + 1.00 = 6.00.
+	if rt.Cost != 6.00 {
+		t.Errorf("repo-a cost: got %f, want 6.00 (parent 5.00 + child 1.00, counted once)", rt.Cost)
+	}
+	// Only the parent counts as a top-level session.
+	if rt.Sessions != 1 {
+		t.Errorf("repo-a sessions: got %d, want 1 (top-level only)", rt.Sessions)
+	}
+}
+
+// TestTrendByModel_CountsChildCostOnce proves the cost-once invariant on the
+// per-model breakdown for the dangerous mixed-model case: a child running a
+// different model than its parent contributes spend to a model with zero
+// top-level sessions. That cost must still appear (counted once). A regression
+// that filtered the cost SUM by parent_id would make the child-only model row
+// vanish entirely with no other failing test.
+func TestTrendByModel_CountsChildCostOnce(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now()
+	// Parent on opus, cost 5.00, top-level.
+	if err := db.SaveSession(&session.Session{
+		ID: "parent-1", TotalCost: 5.00, InputTokens: 500,
+		StartedAt: now.Add(-2 * time.Hour), LastActive: now,
+		Model: "claude-opus-4-6",
+	}); err != nil {
+		t.Fatalf("SaveSession(parent) failed: %v", err)
+	}
+	// Child on sonnet (different model), cost 1.00, parent_id set.
+	if err := db.SaveSession(&session.Session{
+		ID: "child-1", ParentID: "parent-1", TotalCost: 1.00, InputTokens: 100,
+		StartedAt: now.Add(-1 * time.Hour), LastActive: now,
+		Model: "claude-sonnet-4-6",
+	}); err != nil {
+		t.Fatalf("SaveSession(child) failed: %v", err)
+	}
+
+	result, err := db.TrendData("7d", "")
+	if err != nil {
+		t.Fatalf("TrendData failed: %v", err)
+	}
+
+	byModel := make(map[string]ModelTrend, len(result.ByModel))
+	for _, mt := range result.ByModel {
+		byModel[mt.Model] = mt
+	}
+
+	opus, ok := byModel["claude-opus-4-6"]
+	if !ok {
+		t.Fatalf("expected opus model row, got models %v", byModel)
+	}
+	if opus.Cost != 5.00 {
+		t.Errorf("opus cost: got %f, want 5.00", opus.Cost)
+	}
+	if opus.Sessions != 1 {
+		t.Errorf("opus sessions: got %d, want 1", opus.Sessions)
+	}
+
+	// The child-only model must still appear with its cost counted once, even
+	// though it has zero top-level sessions.
+	sonnet, ok := byModel["claude-sonnet-4-6"]
+	if !ok {
+		t.Fatalf("expected child-only sonnet model row to appear, got models %v", byModel)
+	}
+	if sonnet.Cost != 1.00 {
+		t.Errorf("sonnet (child-only) cost: got %f, want 1.00 (child spend counted once)", sonnet.Cost)
+	}
+	if sonnet.Sessions != 0 {
+		t.Errorf("sonnet (child-only) sessions: got %d, want 0 (no top-level session on this model)", sonnet.Sessions)
+	}
+}
+
 func TestPercentile(t *testing.T) {
 	data := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
 	if got := percentile(data, 0.5); got != 6 {
@@ -899,7 +1151,7 @@ func TestTrendData_InvalidWindow(t *testing.T) {
 	}
 }
 
-func TestTrendData_ExcludesChildSessions(t *testing.T) {
+func TestTrendData_CountsChildCostOnceButNotAsSession(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
 
@@ -912,7 +1164,8 @@ func TestTrendData_ExcludesChildSessions(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("SaveSession failed: %v", err)
 	}
-	// Child session — should be excluded by the parent_id filter in TrendData
+	// Child session — its cost is summed (counted once) but the child is NOT
+	// counted as a top-level session.
 	if err := db.SaveSession(&session.Session{
 		ID: "child-1", ParentID: "parent-1", TotalCost: 1.00, InputTokens: 100,
 		StartedAt: now.Add(-30 * time.Minute), LastActive: now,
@@ -926,12 +1179,14 @@ func TestTrendData_ExcludesChildSessions(t *testing.T) {
 		t.Fatalf("TrendData failed: %v", err)
 	}
 
-	// TrendData excludes child sessions (parent_id IS NULL OR parent_id = '')
+	// SessionCount counts top-level sessions only (parent_id empty): parent only.
 	if result.Summary.SessionCount != 1 {
 		t.Errorf("expected 1 session (parent only), got %d", result.Summary.SessionCount)
 	}
-	if result.Summary.TotalCost != 5.00 {
-		t.Errorf("expected cost 5.00 (parent only), got %f", result.Summary.TotalCost)
+	// Cost is summed across ALL rows so the child's spend is counted once:
+	// 5.00 (parent) + 1.00 (child) = 6.00.
+	if result.Summary.TotalCost != 6.00 {
+		t.Errorf("expected cost 6.00 (parent 5.00 + child 1.00, counted once), got %f", result.Summary.TotalCost)
 	}
 }
 
@@ -2039,6 +2294,64 @@ func TestAggregateStatsByRepo(t *testing.T) {
 	}
 }
 
+// TestAggregateStatsByRepo_IncludesChildCostOnce proves the cost-once invariant
+// for the per-repo lifetime aggregate: a workflow child (parent_id set, same
+// repo) has its spend summed into the repo total exactly once. Children share
+// the parent's repo_id, so a regression that filtered child cost out would
+// undercount the repo's CostByRepo and TotalCost.
+func TestAggregateStatsByRepo_IncludesChildCostOnce(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now()
+	if err := db.UpsertRepo(&repo.Repo{ID: "repo-agg", Name: "repo-agg"}); err != nil {
+		t.Fatalf("UpsertRepo failed: %v", err)
+	}
+	// Parent: top-level session on opus, cost 5.00.
+	if err := db.SaveSession(&session.Session{
+		ID: "parent-1", RepoID: "repo-agg", TotalCost: 5.00, InputTokens: 500, OutputTokens: 250,
+		StartedAt: now.Add(-10 * time.Minute), LastActive: now,
+		Model: "claude-opus-4-6",
+	}); err != nil {
+		t.Fatalf("SaveSession(parent) failed: %v", err)
+	}
+	// Child: workflow agent on sonnet (different model), same repo, cost 1.00.
+	if err := db.SaveSession(&session.Session{
+		ID: "child-1", RepoID: "repo-agg", ParentID: "parent-1", TotalCost: 1.00, InputTokens: 100, OutputTokens: 50,
+		StartedAt: now.Add(-5 * time.Minute), LastActive: now,
+		Model: "claude-sonnet-4-6",
+	}); err != nil {
+		t.Fatalf("SaveSession(child) failed: %v", err)
+	}
+
+	agg, err := db.AggregateStatsByRepo("repo-agg")
+	if err != nil {
+		t.Fatalf("AggregateStatsByRepo failed: %v", err)
+	}
+	// Parent 5.00 + child 1.00, counted once.
+	if agg.TotalCost != 6.00 {
+		t.Errorf("TotalCost: got %f, want 6.00 (parent 5.00 + child 1.00, counted once)", agg.TotalCost)
+	}
+	if agg.CostByRepo["repo-agg"] != 6.00 {
+		t.Errorf("CostByRepo[repo-agg]: got %f, want 6.00", agg.CostByRepo["repo-agg"])
+	}
+	if agg.InputTokens != 600 {
+		t.Errorf("InputTokens: got %d, want 600", agg.InputTokens)
+	}
+	// Both rows count toward the per-repo aggregate session count (this aggregate
+	// counts every row; trend SessionCount is the top-level-only definition).
+	if agg.SessionCount != 2 {
+		t.Errorf("SessionCount: got %d, want 2", agg.SessionCount)
+	}
+	// The child's distinct model still contributes its cost to the model breakdown.
+	if agg.CostByModel["claude-sonnet-4-6"] != 1.00 {
+		t.Errorf("CostByModel[sonnet] (child-only model): got %f, want 1.00", agg.CostByModel["claude-sonnet-4-6"])
+	}
+	if agg.CostByModel["claude-opus-4-6"] != 5.00 {
+		t.Errorf("CostByModel[opus]: got %f, want 5.00", agg.CostByModel["claude-opus-4-6"])
+	}
+}
+
 func TestAggregateStats_WithSinceFilter(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)
@@ -2615,3 +2928,105 @@ func TestListSessionsByRepo_Pagination(t *testing.T) {
 		t.Error("page 1 and page 2 returned the same first session")
 	}
 }
+
+// TestListWorkflows_Aggregates verifies one aggregate row per distinct
+// workflow_id, with cost summed once across the workflow's agents, and rows
+// with an empty workflow_id excluded.
+func TestListWorkflows_Aggregates(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now()
+	save := func(id, wf string, cost float64) {
+		if err := db.SaveSession(&session.Session{
+			ID: id, WorkflowID: wf, TotalCost: cost,
+			StartedAt: now.Add(-time.Minute), LastActive: now,
+		}); err != nil {
+			t.Fatalf("SaveSession(%s): %v", id, err)
+		}
+	}
+	save("agent-1", "wf_1", 1.00)
+	save("agent-2", "wf_1", 0.50)
+	save("agent-3", "wf_2", 2.00)
+	save("plain", "", 9.99) // empty workflow_id must be excluded
+
+	workflows, err := db.ListWorkflows()
+	if err != nil {
+		t.Fatalf("ListWorkflows failed: %v", err)
+	}
+	if len(workflows) != 2 {
+		t.Fatalf("expected 2 workflows, got %d: %+v", len(workflows), workflows)
+	}
+
+	byID := make(map[string]WorkflowRow)
+	for _, w := range workflows {
+		byID[w.WorkflowID] = w
+	}
+	if _, ok := byID[""]; ok {
+		t.Error("empty workflow_id should be excluded from ListWorkflows")
+	}
+	wf1, ok := byID["wf_1"]
+	if !ok {
+		t.Fatalf("wf_1 missing from results: %+v", workflows)
+	}
+	if wf1.AgentCount != 2 {
+		t.Errorf("wf_1 AgentCount = %d, want 2", wf1.AgentCount)
+	}
+	if wf1.TotalCost != 1.50 {
+		t.Errorf("wf_1 TotalCost = %f, want 1.50", wf1.TotalCost)
+	}
+}
+
+// TestListReplayEvents_IncludesChildren locks in the UNION-vs-per-session
+// distinction: replay merges a parent's events with its direct children's
+// events chronologically, while ListEvents returns only the session's own.
+func TestListReplayEvents_IncludesChildren(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	if err := db.SaveSession(&session.Session{
+		ID: "p1", StartedAt: base, LastActive: base,
+	}); err != nil {
+		t.Fatalf("SaveSession(p1): %v", err)
+	}
+	if err := db.SaveSession(&session.Session{
+		ID: "agent-1", ParentID: "p1", StartedAt: base, LastActive: base,
+	}); err != nil {
+		t.Fatalf("SaveSession(agent-1): %v", err)
+	}
+
+	batch := &EventBatch{Events: []EventInsert{
+		{SessionID: "p1", Event: &parser.Event{
+			Type: "assistant", Role: "assistant", ContentText: "parent msg",
+			Timestamp: base, UUID: "u-parent",
+		}},
+		{SessionID: "agent-1", Event: &parser.Event{
+			Type: "assistant", Role: "assistant", ContentText: "child msg",
+			Timestamp: base.Add(time.Second), UUID: "u-child",
+		}},
+	}}
+	if err := db.PersistBatch(batch); err != nil {
+		t.Fatalf("PersistBatch failed: %v", err)
+	}
+
+	replay, err := db.ListReplayEvents("p1", 1000, 0)
+	if err != nil {
+		t.Fatalf("ListReplayEvents failed: %v", err)
+	}
+	if len(replay) != 2 {
+		t.Fatalf("ListReplayEvents returned %d events, want 2 (parent + child)", len(replay))
+	}
+	if replay[0].ContentPreview != "parent msg" || replay[1].ContentPreview != "child msg" {
+		t.Errorf("replay order wrong: [0]=%q [1]=%q", replay[0].ContentPreview, replay[1].ContentPreview)
+	}
+
+	own, err := db.ListEvents("p1", 100, 0)
+	if err != nil {
+		t.Fatalf("ListEvents failed: %v", err)
+	}
+	if len(own) != 1 {
+		t.Fatalf("ListEvents returned %d events, want 1 (parent only)", len(own))
+	}
+}
+

--- a/internal/watcher/watcher.go
+++ b/internal/watcher/watcher.go
@@ -36,6 +36,13 @@ const (
 	activeWindow       = 30 * time.Second // how long after last emit a file is considered "active"
 )
 
+// Agent-kind classifications derived from the JSONL file path by classifyPath.
+const (
+	kindSession       = "session"
+	kindSubagent      = "subagent"
+	kindWorkflowAgent = "workflow_agent"
+)
+
 // defaultBasePaths are the well-known locations Claude Code writes session files.
 var defaultBasePaths = []string{
 	"~/.claude/projects/",
@@ -55,6 +62,13 @@ type Event struct {
 	Label string
 	// Bootstrap is true for events emitted from historical data read on startup.
 	Bootstrap bool
+	// Workflow/agent identity derived from the file path by classifyPath.
+	// AgentKind is one of: session, subagent, workflow_agent.
+	// AgentID is the 'agent-<id>' file stem (== SessionID for shapes 2/3); empty for normal sessions.
+	// WorkflowID is the 'wf_<id>' directory name for shape 3; empty otherwise.
+	WorkflowID string
+	AgentID    string
+	AgentKind  string
 }
 
 // fileState tracks our read position within a single JSONL file.
@@ -477,6 +491,7 @@ func (w *Watcher) emit(filePath string, line []byte) {
 	sessionID := sessionIDFromPath(filePath)
 	projectDir := projectDirFromPath(filePath)
 	label := w.labelForPath(filePath)
+	kind, agentID, workflowID := classifyPath(filePath)
 
 	ev := Event{
 		SessionID:  sessionID,
@@ -485,6 +500,9 @@ func (w *Watcher) emit(filePath string, line []byte) {
 		Line:       append([]byte(nil), line...), // copy
 		Label:      label,
 		Bootstrap:  w.bootstrapping,
+		WorkflowID: workflowID,
+		AgentID:    agentID,
+		AgentKind:  kind,
 	}
 
 	if !w.bootstrapping {
@@ -532,6 +550,47 @@ func sessionIDFromPath(path string) string {
 // projectDirFromPath returns the name of the immediate parent directory.
 func projectDirFromPath(path string) string {
 	return filepath.Base(filepath.Dir(path))
+}
+
+// classifyPath derives the workflow/agent identity of a JSONL file from its path.
+// It returns (kind, agentID, workflowID) for the three known on-disk shapes:
+//
+//	shape 1 normal:        <uuid>.jsonl                                           -> (kindSession,       "",           "")
+//	shape 2 task subagent: <parent>/subagents/agent-<id>.jsonl                    -> (kindSubagent,      "agent-<id>", "")
+//	shape 3 workflow:      <parent>/subagents/workflows/wf_<id>/agent-<id>.jsonl  -> (kindWorkflowAgent, "agent-<id>", "wf_<id>")
+//
+// It is a pure function of the path (mirrors sessionIDFromPath/projectDirFromPath)
+// and is independent of pipeline parentage logic.
+func classifyPath(path string) (kind, agentID, workflowID string) {
+	stem := strings.TrimSuffix(filepath.Base(path), ".jsonl")
+	if !strings.HasPrefix(stem, "agent-") {
+		return kindSession, "", ""
+	}
+	agentID = stem
+	// Walk UP looking for a wf_<id> segment and/or a subagents segment.
+	hasSubagents := false
+	wf := ""
+	dir := filepath.Dir(path)
+	for dir != "." && dir != string(filepath.Separator) {
+		base := filepath.Base(dir)
+		if base == "subagents" {
+			hasSubagents = true
+		}
+		if wf == "" && strings.HasPrefix(base, "wf_") {
+			wf = base
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	if hasSubagents && wf != "" {
+		return kindWorkflowAgent, agentID, wf
+	}
+	// shape 2, or defensive fallback (agent-* file without a subagents/ ancestor):
+	// classify as a subagent so it is never mistaken for a top-level session.
+	return kindSubagent, agentID, ""
 }
 
 // expandHome replaces a leading "~/" with the actual home directory.

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -75,6 +75,88 @@ func TestProjectDirFromPath(t *testing.T) {
 	}
 }
 
+func TestClassifyPath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		path, kind, agentID, workflowID string
+	}{
+		// shape 1 normal session
+		{"/home/u/.claude/projects/hash/abc-123.jsonl", kindSession, "", ""},
+		{"/home/u/.claude/projects/hash/abc-123/session.jsonl", kindSession, "", ""},
+		// shape 2 task subagent
+		{"/home/u/.claude/projects/hash/abc-123/subagents/agent-xyz.jsonl", kindSubagent, "agent-xyz", ""},
+		// shape 3 workflow agent
+		{"/home/u/.claude/projects/hash/abc-123/subagents/workflows/wf_def/agent-xyz.jsonl", kindWorkflowAgent, "agent-xyz", "wf_def"},
+		// defensive: agent-* file without a subagents/ ancestor -> subagent, no workflow
+		{"/tmp/agent-loose.jsonl", kindSubagent, "agent-loose", ""},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			k, a, w := classifyPath(tc.path)
+			if k != tc.kind || a != tc.agentID || w != tc.workflowID {
+				t.Errorf("classifyPath(%q) = (%q,%q,%q), want (%q,%q,%q)", tc.path, k, a, w, tc.kind, tc.agentID, tc.workflowID)
+			}
+		})
+	}
+}
+
+func TestWatcher_EmitsWorkflowIdentity(t *testing.T) {
+	// Integration test: a workflow-shaped agent file should propagate
+	// AgentKind/AgentID/WorkflowID onto the Event while SessionID stays the stem.
+	dir := t.TempDir()
+
+	wfDir := filepath.Join(dir, "parent-uuid", "subagents", "workflows", "wf_x")
+	if err := os.MkdirAll(wfDir, 0755); err != nil {
+		t.Fatalf("mkdir wf dir: %v", err)
+	}
+	jsonlPath := filepath.Join(wfDir, "agent-7.jsonl")
+	f, err := os.Create(jsonlPath)
+	if err != nil {
+		t.Fatalf("creating jsonl file: %v", err)
+	}
+	f.Close()
+
+	w := newTestWatcher(t, []string{dir})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events := w.Start(ctx)
+	time.Sleep(100 * time.Millisecond)
+
+	line := `{"type":"user","message":{"role":"user","content":"workflow line"},"sessionId":"parent-uuid","uuid":"uuid-wf1","isSidechain":true,"timestamp":"2024-01-01T00:00:00Z"}`
+	af, err := os.OpenFile(jsonlPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("opening jsonl for append: %v", err)
+	}
+	if _, err := af.WriteString(line + "\n"); err != nil {
+		af.Close()
+		t.Fatalf("writing line: %v", err)
+	}
+	af.Close()
+
+	select {
+	case ev := <-events:
+		if ev.AgentKind != kindWorkflowAgent {
+			t.Errorf("AgentKind: got %q, want %q", ev.AgentKind, kindWorkflowAgent)
+		}
+		if ev.AgentID != "agent-7" {
+			t.Errorf("AgentID: got %q, want agent-7", ev.AgentID)
+		}
+		if ev.WorkflowID != "wf_x" {
+			t.Errorf("WorkflowID: got %q, want wf_x", ev.WorkflowID)
+		}
+		// Keying is unchanged: SessionID is still the file stem.
+		if ev.SessionID != "agent-7" {
+			t.Errorf("SessionID: got %q, want agent-7 (keying unchanged)", ev.SessionID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for watcher event")
+	}
+}
+
 func TestExpandHome_ExpandsHomePath(t *testing.T) {
 	t.Parallel()
 	home, err := os.UserHomeDir()

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -20,8 +20,14 @@ export async function fetchGroupedSessions(): Promise<GroupedSessions> {
   return request<GroupedSessions>(`/api/sessions?group=activity`);
 }
 
-export async function fetchSessions(limit = 50, offset = 0): Promise<Session[]> {
-  return request<Session[]>(`/api/sessions?limit=${limit}&offset=${offset}`);
+export async function fetchSessions(
+  limit = 50,
+  offset = 0,
+  workflow?: string,
+): Promise<Session[]> {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  if (workflow) params.set('workflow', workflow);
+  return request<Session[]>(`/api/sessions?${params}`);
 }
 
 export async function fetchSearch(query: string, limit = 50): Promise<Event[]> {

--- a/web/src/components/graph-view.ts
+++ b/web/src/components/graph-view.ts
@@ -15,6 +15,7 @@ interface GraphNode {
   vy: number;
   radius: number;
   color: string;
+  workflowColor?: string;
   label: string;
   session: Session;
 }
@@ -219,6 +220,17 @@ function resizeCanvas(): void {
   if (ctx) ctx.scale(dpr, dpr);
 }
 
+/** Deterministic per-workflow tint so all agents of a workflow share a color. */
+function workflowTint(workflowId: string | undefined): string | undefined {
+  if (!workflowId) return undefined;
+  const palette = ['#7c5cff', '#1f9d8f', '#d98c2b', '#c0567a', '#3a86ff', '#8ab017'];
+  let h = 0;
+  for (let i = 0; i < workflowId.length; i++) {
+    h = (h * 31 + workflowId.charCodeAt(i)) >>> 0;
+  }
+  return palette[h % palette.length];
+}
+
 function rebuildNodes(): void {
   if (!canvas) return;
   const now = Date.now();
@@ -274,6 +286,7 @@ function rebuildNodes(): void {
       vy: old?.vy ?? 0,
       radius,
       color,
+      workflowColor: workflowTint(sess.workflowId),
       label,
       session: sess,
     };
@@ -302,6 +315,7 @@ function updateNodeColors(): void {
     const sess = state.sessions.get(n.id);
     if (!sess) continue;
     n.session = sess;
+    n.workflowColor = workflowTint(sess.workflowId);
     const newColor = !sess.isActive
       ? '#44445a'
       : sess.status === 'thinking'
@@ -367,6 +381,34 @@ function simulate(): void {
     b.vy -= fy;
   }
 
+  // Intra-workflow clustering: weak pull toward each workflow's centroid so
+  // nodes sharing a workflowId drift together. Weaker than edge attraction
+  // (0.005 < 0.01) so parent-child edges still dominate; gated on workflowId so
+  // non-workflow graphs are unaffected and still settle.
+  const workflowGroups = new Map<string, GraphNode[]>();
+  for (const n of nodes) {
+    const wf = n.session.workflowId;
+    if (!wf) continue;
+    const group = workflowGroups.get(wf);
+    if (group) group.push(n);
+    else workflowGroups.set(wf, [n]);
+  }
+  for (const group of workflowGroups.values()) {
+    if (group.length < 2) continue;
+    let gx = 0,
+      gy = 0;
+    for (const n of group) {
+      gx += n.x;
+      gy += n.y;
+    }
+    gx /= group.length;
+    gy /= group.length;
+    for (const n of group) {
+      n.vx += (gx - n.x) * 0.005;
+      n.vy += (gy - n.y) * 0.005;
+    }
+  }
+
   // Center gravity + damping + bounds
   const cx = w / 2,
     cy = h / 2;
@@ -414,6 +456,18 @@ function draw(): void {
 
   // Nodes
   for (const n of nodes) {
+    // Faint workflow halo so members of the same workflow read as a group,
+    // without losing the status fill color below.
+    if (n.workflowColor) {
+      ctx.globalAlpha = 0.5;
+      ctx.strokeStyle = n.workflowColor;
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, n.radius + 3, 0, Math.PI * 2);
+      ctx.stroke();
+      ctx.globalAlpha = 1.0;
+    }
+
     ctx.globalAlpha = n === hovering ? 1.0 : 0.7;
     ctx.fillStyle = n.color;
     ctx.beginPath();

--- a/web/src/components/history-view.ts
+++ b/web/src/components/history-view.ts
@@ -199,6 +199,20 @@ function groupRows(rows: Session[]): { parent: Session; children: Session[] }[] 
   }));
 }
 
+/** Reduce children into one entry per distinct non-empty workflowId. */
+function workflowSummary(children: Session[]): { id: string; count: number; cost: number }[] {
+  const byWorkflow = new Map<string, { id: string; count: number; cost: number }>();
+  for (const c of children) {
+    const id = c.workflowId;
+    if (!id) continue;
+    const entry = byWorkflow.get(id) || { id, count: 0, cost: 0 };
+    entry.count += 1;
+    entry.cost += c.totalCost;
+    byWorkflow.set(id, entry);
+  }
+  return [...byWorkflow.values()];
+}
+
 function show(): void {
   if (!container) return;
   container.innerHTML = '';
@@ -277,6 +291,7 @@ function show(): void {
   for (const { parent, children } of grouped) {
     const hasChildren = children.length > 0;
     const isCollapsed = collapsedParents.has(parent.id) || !state.historyShowSubagents;
+    const workflows = workflowSummary(children);
 
     // Parent row
     const tr = createRow(parent, false);
@@ -323,12 +338,34 @@ function show(): void {
         const childCost = children.reduce((sum, c) => sum + c.totalCost, 0);
         badge.textContent = `(${children.length} subagent${children.length > 1 ? 's' : ''}, $${childCost.toFixed(2)})`;
         nameCell.appendChild(badge);
+
+        // Per-workflow badges (additive to the subagent badge)
+        for (const wf of workflows) {
+          const wfBadge = document.createElement('span');
+          wfBadge.className = 'history-subagent-badge';
+          const shortId = wf.id.replace(/^wf_/, '').slice(0, 8);
+          wfBadge.textContent = `wf ${shortId} (${wf.count} agent${wf.count > 1 ? 's' : ''}, $${wf.cost.toFixed(2)})`;
+          nameCell.appendChild(wfBadge);
+        }
       }
     }
     tbody.appendChild(tr);
 
     // Child rows (if not collapsed)
     if (hasChildren && !isCollapsed) {
+      // Workflow summary bands heading the agents that share each workflowId
+      for (const wf of workflows) {
+        const bandTr = document.createElement('tr');
+        bandTr.className = 'history-child-row history-workflow-band';
+        for (const col of COLUMNS) {
+          const td = document.createElement('td');
+          if (col.key === 'session') {
+            td.textContent = `Workflow wf_${wf.id.replace(/^wf_/, '')} — ${wf.count} agent${wf.count > 1 ? 's' : ''} · $${wf.cost.toFixed(2)}`;
+          }
+          bandTr.appendChild(td);
+        }
+        tbody.appendChild(bandTr);
+      }
       for (const child of children) {
         const childTr = createRow(child, true);
         tbody.appendChild(childTr);

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -394,3 +394,15 @@ body {
   margin-left: 8px;
   font-style: italic;
 }
+
+.history-workflow-band {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.02));
+}
+
+.history-workflow-band td {
+  color: var(--cyan, #56b6c2);
+  font-size: 10px;
+  font-style: italic;
+  opacity: 0.85;
+  cursor: default;
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -23,6 +23,9 @@ export interface Session {
   taskDescription: string;
   version?: string;
   entrypoint?: string;
+  workflowId?: string;
+  agentId?: string;
+  agentKind?: string;
 }
 
 export interface GroupedSessions {


### PR DESCRIPTION
## Phase 2 — first-class Claude Code Workflows

> **Stacked on #219 (Phase 1), which is stacked on #218 (Phase 0).** Merge in order; GitHub retargets each as the base merges. This diff shows only Phase 2.

Builds on Phase 1's parentage fix to make Workflows a properly-aggregated, first-class concept end to end.

### Schema & identity
- **Migration 013** adds `sessions.workflow_id` / `agent_id` / `agent_kind` (+ `idx_sessions_workflow`). `parent_id` is reused for parentage (no redundant column).
- **`watcher.classifyPath`** derives `(kind, agentID, workflowID)` from the path and stamps them on `watcher.Event`; the pipeline records them on the session. `agent_id` is the full `agent-<id>` stem — **identical for live ingestion and backfill** (a consistency bug where backfill stored the bare id was caught and fixed).
- `session.Session` gains persisted `WorkflowID`/`AgentID`/`AgentKind`, propagated through **every** store column site (`sessionSelectCols`, `SessionRow`, `ToSession`, `SaveSession`, `FlushSessions`, `scanSessionRows`) — column-count kept consistent so scans can't panic.

### Aggregation
- `ListSessionsByWorkflow` + `ListWorkflows` (one row per `workflow_id`: agent count, summed cost, last-seen).
- **Trend cost-counted-once:** keep the parent filter for session *counts*, but `SUM` cost/tokens across all rows (incl. child agents) so a workflow's spend is counted exactly once where it was incurred. byRepo/byModel breakdowns now asserted.

### Backfill & API
- `internal/store/backfill.go`: one-time, **idempotent, marker-guarded** (`settings.backfill_v013_done`) backfill that links the ~797 existing agent transcripts. Runs after migrations, before the watcher bootstrap, and **never blocks the daemon** (failure → retry next start).
- `--rebuild-history` forces the backfill to re-run (re-ingest is inherent to the watcher's offset-0 bootstrap, deduped on persist).
- `GET /api/sessions?workflow=<id>`, `GET /api/workflows`, and the **replay endpoint now UNIONs child events** so a workflow replays as a unit (parameterized; injection-safe). OpenAPI + README updated.

### Frontend (additive, type-safe)
- `types.ts` gains `workflowId`/`agentId`/`agentKind`; `history-view` shows a workflow summary band within a parent's nested children; `graph-view` clusters/colors nodes sharing a `workflow_id`.

### Verification
`go test ./internal/... ./cmd/... -count=1` → 11 packages green; `go vet` clean; `web` `tsc --noEmit` + `lint` + `build` clean.

### Notes / deferred (low risk)
- FE changes are verified by `tsc`/lint/build only — the frontend test runner arrives in Phase 3 (MR4).
- Migration 013 `Down` (used only by the manual `migrate rollback` CLI) isn't exercised by a test — candidate for Phase 3.
- `agent_kind` serializes `"session"` for normal sessions (not omitted); FE treats `"session"` ≡ absent.

Implemented + adversarially self-reviewed (correctness + silent-failure/data-integrity + test-coverage); the one HIGH (trend cost-once unverified for breakdowns) was fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)