### PR TITLE
fix: add missing strings import in handlers.go

### DIFF
--- a/cmd/claude-monitor/handlers.go
+++ b/cmd/claude-monitor/handlers.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/zxela/claude-monitor/api"


### PR DESCRIPTION
## Summary

CI on `main` is failing because the session autopsy export change (#217) used the `strings` package in `cmd/claude-monitor/handlers.go` (8 call sites) without importing it. This broke three CI steps at once:

- `go build ./...`
- `go vet ./...`
- `golangci-lint` (reported as a `typecheck` failure)

## Fix

Add the missing `strings` import to the stdlib import group.

## Verification

Run locally (with the CI embed placeholder in place):

- ✅ `go build ./...`
- ✅ `go vet ./...`
- ✅ `go test ./cmd/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)