### PR TITLE
feat: Cost by Session analytics (default); mark Cost by Repo approximate

### DIFF
--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -224,6 +224,19 @@ type ModelTrend struct {
 	Sessions int     `json:"sessions"`
 }
 
+// SessionTrend holds the cost/token breakdown for one top-level session, with
+// subagent/workflow child rows rolled up into their root ancestor. This is the
+// honest default unit for cost: cost-by-repo over-attributes a session that
+// spans multiple projects to a single project, whereas cost-by-session keeps a
+// run's spend intact regardless of how many directories it touched.
+type SessionTrend struct {
+	SessionID   string  `json:"sessionId"`
+	SessionName string  `json:"sessionName"`
+	Cost        float64 `json:"cost"`
+	Tokens      int64   `json:"tokens"`
+	Agents      int     `json:"agents"` // rows rolled up (root + descendants)
+}
+
 // TrendSummary holds totals across all buckets.
 type TrendSummary struct {
 	TotalCost       float64 `json:"totalCost"`
@@ -236,9 +249,10 @@ type TrendSummary struct {
 type TrendResult struct {
 	Window  string        `json:"window"`
 	Buckets []TrendBucket `json:"buckets"`
-	ByRepo  []RepoTrend   `json:"byRepo"`
-	ByModel []ModelTrend  `json:"byModel"`
-	Summary TrendSummary  `json:"summary"`
+	ByRepo    []RepoTrend    `json:"byRepo"`
+	ByModel   []ModelTrend   `json:"byModel"`
+	BySession []SessionTrend `json:"bySession"`
+	Summary   TrendSummary   `json:"summary"`
 }
 
 // StorageInfo holds database storage statistics.
@@ -884,6 +898,11 @@ func (d *DB) TrendData(window string, repoID string) (*TrendResult, error) {
 		return nil, err
 	}
 
+	bySession, err := d.trendBySession(p)
+	if err != nil {
+		return nil, err
+	}
+
 	// Build summary from buckets
 	var summary TrendSummary
 	var totalEffInput, totalCacheRead int64
@@ -899,11 +918,12 @@ func (d *DB) TrendData(window string, repoID string) (*TrendResult, error) {
 	}
 
 	return &TrendResult{
-		Window:  window,
-		Buckets: buckets,
-		ByRepo:  byRepo,
-		ByModel: byModel,
-		Summary: summary,
+		Window:    window,
+		Buckets:   buckets,
+		ByRepo:    byRepo,
+		ByModel:   byModel,
+		BySession: bySession,
+		Summary:   summary,
 	}, nil
 }
 
@@ -1067,6 +1087,72 @@ func (d *DB) trendByModel(p *trendParams) ([]ModelTrend, error) {
 		byModel = []ModelTrend{}
 	}
 	return byModel, nil
+}
+
+// trendBySessionLimit caps how many top sessions the cost-by-session breakdown
+// returns (a chart of every session would be unreadable; the long tail is tiny).
+const trendBySessionLimit = 20
+
+// trendBySession rolls cost/tokens up to each top-level (root) session, summing
+// subagent/workflow child rows into their root ancestor via a recursive walk of
+// parent_id. This is the default analytics breakdown: unlike cost-by-repo it does
+// not over-attribute a multi-project run to a single project, since a session's
+// whole tree stays together. Returns the top sessions by cost.
+func (d *DB) trendBySession(p *trendParams) ([]SessionTrend, error) {
+	// Match started_at's RFC3339-Z storage format (see windowWhere above).
+	sessWindowWhere := fmt.Sprintf("s.started_at >= strftime('%%Y-%%m-%%dT%%H:%%M:%%SZ', datetime('now', '%s'))", p.interval)
+	if p.repoID != "" {
+		sessWindowWhere += " AND s.repo_id = ?"
+	}
+	// anc maps every session to its root ancestor (the top-level parent_id-empty
+	// row). Rows in the window are then attributed to their root and summed, so a
+	// parent and all its subagents collapse into one bar. Orphans (parent not in
+	// the table) fall back to being their own root via COALESCE.
+	query := fmt.Sprintf(`
+		WITH RECURSIVE anc(id, root) AS (
+			SELECT id, id FROM sessions WHERE parent_id IS NULL OR parent_id = ''
+			UNION ALL
+			SELECT s.id, a.root FROM sessions s JOIN anc a ON s.parent_id = a.id
+		)
+		SELECT COALESCE(a.root, s.id) AS root_id,
+		       COALESCE(rt.session_name, ''),
+		       COALESCE(rt.task_description, ''),
+		       COALESCE(SUM(s.total_cost), 0),
+		       COALESCE(SUM(s.input_tokens + s.output_tokens + s.cache_read_tokens + s.cache_creation_tokens), 0),
+		       COUNT(*)
+		FROM sessions s
+		LEFT JOIN anc a ON a.id = s.id
+		LEFT JOIN sessions rt ON rt.id = COALESCE(a.root, s.id)
+		WHERE %s
+		GROUP BY root_id
+		ORDER BY SUM(s.total_cost) DESC
+		LIMIT %d`, sessWindowWhere, trendBySessionLimit)
+
+	rows, err := d.db.Query(query, p.args...)
+	if err != nil {
+		return nil, fmt.Errorf("trendBySession: %w", err)
+	}
+	defer rows.Close()
+
+	bySession := []SessionTrend{}
+	for rows.Next() {
+		var st SessionTrend
+		var name, task string
+		if err := rows.Scan(&st.SessionID, &name, &task, &st.Cost, &st.Tokens, &st.Agents); err != nil {
+			return nil, fmt.Errorf("trendBySession: scan: %w", err)
+		}
+		// Prefer an explicit session name, then the task/prompt; the frontend
+		// falls back to the id when both are empty.
+		st.SessionName = name
+		if st.SessionName == "" {
+			st.SessionName = task
+		}
+		bySession = append(bySession, st)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("trendBySession: rows: %w", err)
+	}
+	return bySession, nil
 }
 
 // percentile returns the value at the given percentile (0-1) from a sorted slice.

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -3104,3 +3104,61 @@ func TestTrendData_24hExcludesOlderSameCalendarDay(t *testing.T) {
 		t.Errorf("totalCost: got %f, want 3.00 (rolling 24h must not include yesterday-00:00 UTC)", result.Summary.TotalCost)
 	}
 }
+
+// TestTrendBySession_RollsUpSubagents verifies the cost-by-session breakdown
+// attributes subagent/workflow child cost to the root session (so a run's whole
+// tree is one bar) rather than splitting it — the honest default unit vs the
+// project-fragmenting cost-by-repo view.
+func TestTrendBySession_RollsUpSubagents(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	now := time.Now().UTC()
+	parent := &session.Session{ID: "root-1", SessionName: "deep dive", TotalCost: 10.0, InputTokens: 100, StartedAt: now.Add(-2 * time.Hour), LastActive: now, Model: "claude-opus-4-8"}
+	c1 := &session.Session{ID: "agent-1", ParentID: "root-1", TotalCost: 3.0, InputTokens: 30, StartedAt: now.Add(-90 * time.Minute), LastActive: now, Model: "claude-opus-4-8"}
+	c2 := &session.Session{ID: "agent-2", ParentID: "root-1", TotalCost: 2.0, InputTokens: 20, StartedAt: now.Add(-80 * time.Minute), LastActive: now, Model: "claude-opus-4-8"}
+	other := &session.Session{ID: "root-2", SessionName: "lint fix", TotalCost: 1.0, InputTokens: 10, StartedAt: now.Add(-1 * time.Hour), LastActive: now, Model: "claude-opus-4-8"}
+	for _, s := range []*session.Session{parent, c1, c2, other} {
+		if err := db.SaveSession(s); err != nil {
+			t.Fatalf("SaveSession(%s): %v", s.ID, err)
+		}
+	}
+
+	res, err := db.TrendData("24h", "")
+	if err != nil {
+		t.Fatalf("TrendData: %v", err)
+	}
+	if len(res.BySession) < 2 {
+		t.Fatalf("BySession: got %d entries, want >=2", len(res.BySession))
+	}
+
+	top := res.BySession[0]
+	if top.SessionID != "root-1" {
+		t.Errorf("top session id: got %q, want root-1", top.SessionID)
+	}
+	if top.Cost != 15.0 {
+		t.Errorf("top session cost: got %f, want 15.00 (10 parent + 3 + 2 subagents)", top.Cost)
+	}
+	if top.Agents != 3 {
+		t.Errorf("top session agents: got %d, want 3 (root + 2 subagents)", top.Agents)
+	}
+	if top.SessionName != "deep dive" {
+		t.Errorf("top session name: got %q, want 'deep dive'", top.SessionName)
+	}
+
+	var foundOther bool
+	for _, s := range res.BySession {
+		if s.SessionID == "root-2" {
+			foundOther = true
+			if s.Cost != 1.0 {
+				t.Errorf("standalone root-2 cost: got %f, want 1.00 (must not absorb other trees)", s.Cost)
+			}
+		}
+		if s.SessionID == "agent-1" || s.SessionID == "agent-2" {
+			t.Errorf("subagent %q should be rolled into its root, not a separate bar", s.SessionID)
+		}
+	}
+	if !foundOther {
+		t.Errorf("standalone session root-2 missing from BySession")
+	}
+}

--- a/web/src/components/analytics-cards.ts
+++ b/web/src/components/analytics-cards.ts
@@ -17,6 +17,14 @@ function darkTheme(): Record<string, unknown> {
   return JSON.parse(JSON.stringify(DARK_THEME));
 }
 
+// Short, readable axis label for a session bar: the session name/prompt trimmed
+// to one line, falling back to a short id when unnamed.
+function sessionLabel(name: string, id: string): string {
+  const trimmed = (name || '').replace(/\s+/g, ' ').trim();
+  if (trimmed) return trimmed.length > 36 ? trimmed.slice(0, 35) + '…' : trimmed;
+  return id.length > 12 ? id.slice(0, 12) : id;
+}
+
 const CARD_DEFS: CardDef[] = [
   {
     id: 'cost-trend',
@@ -90,9 +98,39 @@ const CARD_DEFS: CardDef[] = [
     },
   },
   {
+    id: 'cost-by-session',
+    title: 'Cost by Session',
+    subtitle: 'horizontal bar · subagents rolled into their session',
+    defaultExpanded: true,
+    render(canvas, data) {
+      const rows = data.bySession ?? [];
+      const labels = rows.map((s) => sessionLabel(s.sessionName, s.sessionId));
+      const values = rows.map((s) => s.cost);
+      const opts = darkTheme() as any;
+      opts.indexAxis = 'y';
+      return new Chart(canvas, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'Cost ($)',
+              data: values,
+              backgroundColor: COLORS.green,
+            },
+          ],
+        },
+        options: opts,
+      });
+    },
+  },
+  {
     id: 'cost-by-repo',
     title: 'Cost by Repo',
-    subtitle: 'horizontal bar',
+    // Project attribution is approximate: a session's entire cost is booked to
+    // the project it started in, so a run spanning multiple projects is not
+    // split. Cost by Session (above) is the exact unit.
+    subtitle: '⚠ approximate — whole-session cost booked to its starting project',
     defaultExpanded: false,
     render(canvas, data) {
       const labels = data.byRepo.map((r) => r.repoName || r.repoId);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -131,6 +131,14 @@ export interface ModelTrend {
   sessions: number;
 }
 
+export interface SessionTrend {
+  sessionId: string;
+  sessionName: string;
+  cost: number;
+  tokens: number;
+  agents: number;
+}
+
 export interface TrendSummary {
   totalCost: number;
   effectiveTokens: number;
@@ -143,6 +151,7 @@ export interface TrendResult {
   buckets: TrendBucket[];
   byRepo: RepoTrend[];
   byModel: ModelTrend[];
+  bySession: SessionTrend[];
   summary: TrendSummary;
 }
 


### PR DESCRIPTION
## Why

Cost-per-project is **unreliable when a session spans multiple directories**. Each session carries a single `repo_id` (pinned to the project it started in), so a run that touches several projects books its *entire* cost to one of them — and a project's total silently absorbs spend that happened elsewhere. There's no correct single-project answer for a multi-project session.

So: **session becomes the default cost unit, and the project view is explicitly marked approximate.**

## Changes

**Backend (`internal/store`)**
- `TrendData` now returns `bySession []SessionTrend` — top sessions by cost, with subagent/workflow child rows **rolled up into their root ancestor** via a recursive `parent_id` walk (orphans fall back to themselves). Capped at the top 20 for the chart.
- New `TestTrendBySession_RollsUpSubagents`: a parent + 2 subagents collapse into one bar at the summed cost; standalone sessions stay separate; subagents never appear as their own bar.

**Frontend (`web/src`)**
- New **"Cost by Session"** analytics card — primary, **expanded by default**, placed above "Cost by Repo".
- **"Cost by Repo"** demoted (collapsed) and relabeled: **"⚠ approximate — whole-session cost booked to its starting project"**.

## Verification
Against a snapshot of the real DB, the top "Cost by Session" bar is this audit run — **\$598.53 with all 109 of its subagents rolled into the parent**, vs the old `byRepo` view that lumped everything in `claude-monitor` into one \$984 bar.

- `go vet` + `internal/store` + `cmd` tests green; web `tsc` + 39 vitest pass.
- Playwright: card renders painted, ordered above Cost by Repo, disclaimer present, 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)