### PR TITLE
fix: harden repo attribution — start-pin, parent inheritance, stable cwd

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -91,10 +91,23 @@ func (p *Pipeline) resolvePendingLinks() {
 	p.linkMu.Lock()
 	defer p.linkMu.Unlock()
 	for childID, parentUUID := range p.pendingParentLinks {
-		if _, ok := p.sessions.Get(parentUUID); ok {
+		// Get returns a snapshot copy, so reading parent.RepoID here is safe and
+		// avoids re-entering the store lock from inside the Upsert closure below.
+		if parent, ok := p.sessions.Get(parentUUID); ok {
+			parentRepoID := parent.RepoID
 			p.sessions.Upsert(childID, func(s *session.Session) {
 				if s.ParentID == "" {
 					s.ParentID = parentUUID
+				}
+				// Back-fill repo inheritance for the child-before-parent ordering:
+				// when the child arrived first, its initial event resolved its own
+				// (worktree) cwd to a phantom repo because the parent was unknown.
+				// Now that the parent exists, re-point the child at the parent's
+				// project, mirroring applyRepoResolution's rule 1.
+				if parentRepoID != "" && s.RepoID != parentRepoID {
+					s.RepoID = parentRepoID
+					s.SetRepoSourceRank(repo.SourceGitRemote)
+					s.SetRepoToplevel("")
 				}
 			})
 			p.sessions.LinkChild(parentUUID, childID)
@@ -180,9 +193,16 @@ func (p *Pipeline) Process(ev watcher.Event) {
 	// otherwise fall back to path inference. A "" result means defer to later.
 	resolvedParentID := p.resolveParentID(event, ev)
 
+	// Pre-resolve the parent session's repo_id (also outside the Upsert lock to
+	// avoid re-entering the session-store lock). Child sessions inherit their
+	// parent's project so subagents running in git worktrees don't mint phantom
+	// "agent-<hash>" repos from their own worktree cwd. Empty means "unknown
+	// parent" — fall back to normal cwd resolution.
+	parentRepoID := p.lookupParentRepoID(resolvedParentID)
+
 	// Stage 3: Apply Session
 	sess := p.sessions.Upsert(ev.SessionID, func(s *session.Session) {
-		p.applyEvent(s, event, ev, resolvedRepo, resolvedParentID)
+		p.applyEvent(s, event, ev, resolvedRepo, resolvedParentID, parentRepoID)
 	})
 
 	// Link child to parent
@@ -273,8 +293,10 @@ func (p *Pipeline) flushLoop() {
 // applyEvent updates session state from a parsed event.
 // It delegates to focused helpers for each concern.
 // resolvedParentID is the pre-computed parent session ID (may be empty).
-func (p *Pipeline) applyEvent(s *session.Session, msg *parser.Event, ev watcher.Event, r *repo.Repo, resolvedParentID string) {
-	p.applyRepoResolution(s, msg, r)
+// parentRepoID is the pre-resolved repo_id of that parent (may be empty); when
+// set, a child session inherits it instead of resolving its own (worktree) cwd.
+func (p *Pipeline) applyEvent(s *session.Session, msg *parser.Event, ev watcher.Event, r *repo.Repo, resolvedParentID, parentRepoID string) {
+	p.applyRepoResolution(s, msg, r, parentRepoID)
 	p.applySessionMeta(s, msg, ev)
 	p.applyParentDetection(s, msg, ev, resolvedParentID)
 	p.applyWorkflowIdentity(s, ev)
@@ -297,30 +319,65 @@ func (p *Pipeline) applyWorkflowIdentity(s *session.Session, ev watcher.Event) {
 	}
 }
 
-// applyRepoResolution persists the resolved repo and copies CWD/branch/model metadata.
-func (p *Pipeline) applyRepoResolution(s *session.Session, msg *parser.Event, r *repo.Repo) {
-	if r != nil {
+// applyRepoResolution attributes the session's repo_id and copies branch/model
+// metadata. Three rules, in priority order:
+//
+//  1. Parent inheritance: a child session (one with a known parent) inherits the
+//     parent's repo_id verbatim, instead of resolving its own cwd. This stops
+//     subagents running in git worktrees from minting phantom "agent-<hash>"
+//     repos and fragmenting the parent run across fake projects.
+//  2. Start-pin: once a (non-child) session has a repo_id, it stays pinned to
+//     the START project. A later resolution may only upgrade the resolution
+//     QUALITY of the SAME repository (e.g. a toplevel-basename id replaced by the
+//     git-remote id for that same checkout) — never switch to a different repo,
+//     even if that different repo resolved at a higher source rank.
+//  3. CWD is set once (session start) and never overwritten — see below.
+func (p *Pipeline) applyRepoResolution(s *session.Session, msg *parser.Event, r *repo.Repo, parentRepoID string) {
+	// Rule 1: inherit the parent's project. parentRepoID is non-empty only when
+	// this session has a known parent with a resolved repo_id. Set-once so we
+	// don't thrash if the parent's id later changes; the child stays pinned to
+	// whatever the parent was attributed to at first sight.
+	if parentRepoID != "" {
+		if s.RepoID != parentRepoID {
+			s.RepoID = parentRepoID
+			// Mark as git-remote authority: an inherited id is as trustworthy as
+			// the parent's and must not be downgraded by the child's own cwd.
+			s.SetRepoSourceRank(repo.SourceGitRemote)
+			s.SetRepoToplevel("")
+		}
+	} else if r != nil {
 		newRank := r.SourceRank()
-		// First resolution for this session.
 		if s.RepoID == "" {
+			// First resolution for this session: pin to the START project.
 			s.RepoID = r.ID
 			s.SetRepoSourceRank(newRank)
+			s.SetRepoToplevel(r.Toplevel)
 			if err := p.db.UpsertRepo(r); err != nil {
 				log.Printf("upsert repo error: %v", err)
 			}
-		} else if r.ID != s.RepoID && newRank > s.RepoSourceRank() {
-			// Upgrade to a strictly more authoritative resolution: a non-git
-			// fallback can be upgraded by a git resolution, and a git toplevel
-			// basename can be upgraded by a git remote origin. Never downgrades.
+		} else if r.ID != s.RepoID && newRank > s.RepoSourceRank() && sameRepo(s, r, msg.CWD) {
+			// Upgrade ONLY when the new, higher-authority resolution refers to the
+			// SAME repository as the pinned one (e.g. the start cwd resolved to a
+			// toplevel basename because the git-remote lookup timed out, and a
+			// later event for the same checkout resolves the remote origin id).
+			// A higher-rank resolution for a DIFFERENT project (e.g. cd'ing into
+			// another repo) is intentionally ignored so the project stays pinned
+			// to where the session started. When in doubt, keep the original.
 			s.RepoID = r.ID
 			s.SetRepoSourceRank(newRank)
+			s.SetRepoToplevel(r.Toplevel)
 			if err := p.db.UpsertRepo(r); err != nil {
 				log.Printf("upsert repo error: %v", err)
 			}
 		}
 	}
 
-	if msg.CWD != "" {
+	// Rule 3: CWD reflects session START, not the latest event. Set it once (the
+	// first event that carries a cwd) and never overwrite it, so a card's shown
+	// directory cannot drift away from the project it's attributed to (e.g. after
+	// a `cd`). Repo resolution above still uses the per-event msg.CWD, so this
+	// does not affect attribution.
+	if msg.CWD != "" && s.CWD == "" {
 		s.CWD = msg.CWD
 	}
 	if msg.GitBranch != "" {
@@ -339,6 +396,53 @@ func (p *Pipeline) applyRepoResolution(s *session.Session, msg *parser.Event, r 
 	if msg.Entrypoint != "" && s.Entrypoint == "" {
 		s.Entrypoint = msg.Entrypoint
 	}
+}
+
+// sameRepo reports whether resolution r refers to the SAME repository the
+// session is already pinned to, so a higher-authority resolution may upgrade the
+// id in place (rather than switch projects). newCWD is the cwd r was resolved
+// from. It is deliberately conservative — it returns true only on positive
+// evidence, so an ambiguous case keeps the original pinned repo.
+//
+// Evidence, strongest first:
+//   - identical git working-tree roots (the pinned and new resolutions are in
+//     the same checkout), or one toplevel nested within the other (e.g. the
+//     start cwd was a subdir of the new toplevel, or vice versa); or
+//   - the session has no recorded toplevel (its pin came from a non-git fallback,
+//     i.e. git was unavailable at start) but the new resolution's toplevel
+//     contains the session's START cwd. That is the headline upgrade case: the
+//     start cwd's git-remote lookup timed out → basename fallback, and a later
+//     event for the SAME directory resolves the real git id.
+//
+// pathContains compares on a trailing separator so "/repo" is not treated as a
+// prefix of "/repo2".
+func sameRepo(s *session.Session, r *repo.Repo, newCWD string) bool {
+	if r.Toplevel == "" {
+		// No git root on the incoming resolution — no positive same-repo evidence.
+		return false
+	}
+	if top := s.RepoToplevel(); top != "" {
+		// Both sides are git-backed: compare working-tree roots directly.
+		return pathContains(top, r.Toplevel) || pathContains(r.Toplevel, top)
+	}
+	// The pin is a non-git fallback (no toplevel). Use the session's start cwd:
+	// if it lives inside the incoming resolution's working tree, this is a
+	// higher-confidence resolution of the SAME directory the session started in.
+	if s.CWD != "" {
+		return pathContains(r.Toplevel, s.CWD)
+	}
+	// Last resort: the cwd this resolution came from is the start cwd (first
+	// event), so a containment check against it is still same-directory evidence.
+	return newCWD != "" && pathContains(r.Toplevel, newCWD)
+}
+
+// pathContains reports whether parent is an ancestor of (or equal to) child,
+// comparing on a trailing separator so "/repo" is not a prefix of "/repo2".
+func pathContains(parent, child string) bool {
+	if parent == child {
+		return true
+	}
+	return strings.HasPrefix(child+string(filepath.Separator), parent+string(filepath.Separator))
 }
 
 // applySessionMeta updates session naming, source file tracking, and task description.
@@ -440,6 +544,25 @@ func (p *Pipeline) resolveParentID(msg *parser.Event, ev watcher.Event) string {
 		return parentSessionIDFromPath(ev.FilePath)
 	}
 
+	return ""
+}
+
+// lookupParentRepoID returns the parent session's repo_id so a child can inherit
+// it, or "" if there is no (known) parent. It checks the live session store
+// first (the common case: parent processed before its subagents) and falls back
+// to the persisted sessions table (e.g. the parent was flushed in an earlier run
+// or is being replayed out of order). MUST be called OUTSIDE the session-store
+// Upsert lock — Get takes the store's RLock and would otherwise deadlock.
+func (p *Pipeline) lookupParentRepoID(parentID string) string {
+	if parentID == "" {
+		return ""
+	}
+	if parent, ok := p.sessions.Get(parentID); ok && parent.RepoID != "" {
+		return parent.RepoID
+	}
+	if row, err := p.db.GetSession(parentID); err == nil && row != nil && row.RepoID != "" {
+		return row.RepoID
+	}
 	return ""
 }
 

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1123,12 +1124,17 @@ func TestApplyRepoResolution_UpgradesFallbackToGit(t *testing.T) {
 	defer p.Stop()
 
 	const sid = "upgrade-session"
+	// SAME repository, low confidence then high confidence: the start cwd's git
+	// lookup failed (basename fallback), then a later event for the SAME directory
+	// resolves the git remote. The fallback has no toplevel; same-repo evidence
+	// comes from the session's start cwd living inside the git toplevel.
+	const startCWD = "/work/my-project"
 	fallback := &repo.Repo{ID: "my-project", Name: "my-project", FromGit: false}
-	gitRepo := &repo.Repo{ID: "github.com/acme/my-project", Name: "my-project", URL: "git@github.com:acme/my-project.git", FromGit: true}
+	gitRepo := &repo.Repo{ID: "github.com/acme/my-project", Name: "my-project", URL: "git@github.com:acme/my-project.git", FromGit: true, Toplevel: startCWD}
 
-	// First resolution: non-git fallback.
+	// First resolution: non-git fallback (also records the start cwd).
 	sessions.Upsert(sid, func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, fallback)
+		p.applyRepoResolution(s, &parser.Event{CWD: startCWD}, fallback, "")
 	})
 	sess, _ := sessions.Get(sid)
 	if sess.RepoID != "my-project" {
@@ -1138,9 +1144,9 @@ func TestApplyRepoResolution_UpgradesFallbackToGit(t *testing.T) {
 		t.Error("after fallback: RepoFromGit() = true, want false")
 	}
 
-	// Second resolution: git-backed, different ID -> upgrade.
+	// Second resolution: git-backed for the SAME directory -> upgrade.
 	sessions.Upsert(sid, func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, gitRepo)
+		p.applyRepoResolution(s, &parser.Event{CWD: startCWD}, gitRepo, "")
 	})
 	sess, _ = sessions.Get(sid)
 	if sess.RepoID != "github.com/acme/my-project" {
@@ -1167,7 +1173,7 @@ func TestApplyRepoResolution_NoDowngradeOrThrash(t *testing.T) {
 	fallback := &repo.Repo{ID: "widget", Name: "widget", FromGit: false}
 
 	sessions.Upsert(sid, func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, gitRepo)
+		p.applyRepoResolution(s, &parser.Event{}, gitRepo, "")
 	})
 	sess, _ := sessions.Get(sid)
 	if sess.RepoID != "github.com/acme/widget" || !sess.RepoFromGit() {
@@ -1176,7 +1182,7 @@ func TestApplyRepoResolution_NoDowngradeOrThrash(t *testing.T) {
 
 	// A non-git fallback must NOT downgrade.
 	sessions.Upsert(sid, func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, fallback)
+		p.applyRepoResolution(s, &parser.Event{}, fallback, "")
 	})
 	sess, _ = sessions.Get(sid)
 	if sess.RepoID != "github.com/acme/widget" {
@@ -1188,7 +1194,7 @@ func TestApplyRepoResolution_NoDowngradeOrThrash(t *testing.T) {
 
 	// An identical git resolution must cause no change (r.ID == s.RepoID guard).
 	sessions.Upsert(sid, func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, gitRepo)
+		p.applyRepoResolution(s, &parser.Event{}, gitRepo, "")
 	})
 	sess, _ = sessions.Get(sid)
 	if sess.RepoID != "github.com/acme/widget" {
@@ -1210,12 +1216,16 @@ func TestApplyRepoResolution_RemoteUpgradesToplevel(t *testing.T) {
 	defer p.Stop()
 
 	const sid = "remote-upgrade-session"
-	toplevel := &repo.Repo{ID: "widget", Name: "widget", FromGit: true} // git toplevel basename, no remote URL
-	remote := &repo.Repo{ID: "github.com/acme/widget", Name: "widget", URL: "git@github.com:acme/widget.git", FromGit: true}
+	// Same checkout, resolved two ways: the toplevel-basename id and the
+	// remote-origin id share a git working-tree root, which is the same-repo
+	// evidence that permits the in-place upgrade.
+	const top = "/work/widget"
+	toplevel := &repo.Repo{ID: "widget", Name: "widget", FromGit: true, Toplevel: top} // git toplevel basename, no remote URL
+	remote := &repo.Repo{ID: "github.com/acme/widget", Name: "widget", URL: "git@github.com:acme/widget.git", FromGit: true, Toplevel: top}
 
 	// First: git toplevel basename (rank = SourceGitToplevel).
 	sessions.Upsert(sid, func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, toplevel)
+		p.applyRepoResolution(s, &parser.Event{}, toplevel, "")
 	})
 	sess, _ := sessions.Get(sid)
 	if sess.RepoID != "widget" || sess.RepoSourceRank() != repo.SourceGitToplevel {
@@ -1224,7 +1234,7 @@ func TestApplyRepoResolution_RemoteUpgradesToplevel(t *testing.T) {
 
 	// Then: git remote origin (rank = SourceGitRemote) -> must upgrade.
 	sessions.Upsert(sid, func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, remote)
+		p.applyRepoResolution(s, &parser.Event{}, remote, "")
 	})
 	sess, _ = sessions.Get(sid)
 	if sess.RepoID != "github.com/acme/widget" {
@@ -1236,7 +1246,7 @@ func TestApplyRepoResolution_RemoteUpgradesToplevel(t *testing.T) {
 
 	// A later toplevel resolution must NOT downgrade the remote.
 	sessions.Upsert(sid, func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, &repo.Repo{ID: "widget", Name: "widget", FromGit: true})
+		p.applyRepoResolution(s, &parser.Event{}, &repo.Repo{ID: "widget", Name: "widget", FromGit: true, Toplevel: top}, "")
 	})
 	sess, _ = sessions.Get(sid)
 	if sess.RepoID != "github.com/acme/widget" {
@@ -1260,13 +1270,13 @@ func TestApplyRepoResolution_RestartReupsertPreservesMetadata(t *testing.T) {
 	gitRepo := &repo.Repo{ID: id, Name: "widget", URL: "https://github.com/acme/widget", FromGit: true}
 
 	sessions.Upsert("sess-a", func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, gitRepo)
+		p.applyRepoResolution(s, &parser.Event{}, gitRepo, "")
 	})
 
 	// Simulate restart: a new session for a cwd whose cache entry only has the ID.
 	cacheHit := &repo.Repo{ID: id} // empty Name/URL, FromGit=false
 	sessions.Upsert("sess-b", func(s *session.Session) {
-		p.applyRepoResolution(s, &parser.Event{}, cacheHit)
+		p.applyRepoResolution(s, &parser.Event{}, cacheHit, "")
 	})
 
 	rows, err := db.ListRepos()
@@ -1362,5 +1372,298 @@ func TestLoadMeta_EvictsOldestHalf(t *testing.T) {
 	// metaOrder should match cache size.
 	if len(p.metaOrder) != 251 {
 		t.Errorf("metaOrder length: got %d, want 251", len(p.metaOrder))
+	}
+}
+
+// TestApplyRepoResolution_StartPin_NoFlipToDifferentRepo verifies the start-pin
+// rule: a session that starts in project A (resolved at a LOW rank) must NOT have
+// its repo_id flipped to a DIFFERENT project B even when B resolves at a strictly
+// HIGHER source rank (e.g. the run cd's into another checkout whose git remote
+// resolves). The project stays pinned to where the session started.
+func TestApplyRepoResolution_StartPin_NoFlipToDifferentRepo(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const sid = "startpin-session"
+	// Start: project A resolved at the LOW git-toplevel rank (remote lookup timed out).
+	projectA := &repo.Repo{ID: "alpha", Name: "alpha", FromGit: true, Toplevel: "/work/alpha"}
+	// Later: a DIFFERENT project B at a HIGHER rank (git remote, with URL),
+	// resolved from a cwd inside B's own (different) working tree.
+	projectB := &repo.Repo{ID: "github.com/acme/beta", Name: "beta", URL: "git@github.com:acme/beta.git", FromGit: true, Toplevel: "/work/beta"}
+
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{CWD: "/work/alpha"}, projectA, "")
+	})
+	sess, _ := sessions.Get(sid)
+	if sess.RepoID != "alpha" {
+		t.Fatalf("after start: RepoID = %q, want alpha", sess.RepoID)
+	}
+
+	// Higher-rank, DIFFERENT repo -> must be ignored (start-pin).
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{CWD: "/work/beta"}, projectB, "")
+	})
+	sess, _ = sessions.Get(sid)
+	if sess.RepoID != "alpha" {
+		t.Errorf("start-pin violated: RepoID = %q, want alpha (must not flip to higher-rank different repo beta)", sess.RepoID)
+	}
+	if sess.RepoSourceRank() != repo.SourceGitToplevel {
+		t.Errorf("rank changed: got %d, want %d (no upgrade across repos)", sess.RepoSourceRank(), repo.SourceGitToplevel)
+	}
+}
+
+// TestApplyRepoResolution_StartPin_UpgradesSameRepoSubdir verifies the legitimate
+// upgrade is preserved across a parent/child directory relationship: starting in a
+// subdir (toplevel /work/mono/pkg) then a higher-rank remote resolution for the
+// repo root (/work/mono) is recognised as the SAME repo and upgrades in place.
+func TestApplyRepoResolution_StartPin_UpgradesSameRepoSubdir(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const sid = "subdir-upgrade-session"
+	// Start: toplevel basename, working-tree root is a nested path.
+	start := &repo.Repo{ID: "mono", Name: "mono", FromGit: true, Toplevel: "/work/mono"}
+	// Later: remote origin whose toplevel is the same root.
+	remote := &repo.Repo{ID: "github.com/acme/mono", Name: "mono", URL: "git@github.com:acme/mono.git", FromGit: true, Toplevel: "/work/mono"}
+
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{CWD: "/work/mono/pkg"}, start, "")
+	})
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{CWD: "/work/mono"}, remote, "")
+	})
+	sess, _ := sessions.Get(sid)
+	if sess.RepoID != "github.com/acme/mono" {
+		t.Errorf("same-repo upgrade failed: RepoID = %q, want github.com/acme/mono", sess.RepoID)
+	}
+}
+
+// TestApplyRepoResolution_CWDStaysAtStart verifies the displayed cwd reflects
+// session START and is never overwritten by a later event's cwd (e.g. after a cd),
+// so a card's directory cannot drift away from its pinned project.
+func TestApplyRepoResolution_CWDStaysAtStart(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const sid = "cwd-start-session"
+	r := &repo.Repo{ID: "alpha", Name: "alpha", FromGit: true, Toplevel: "/work/alpha"}
+
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{CWD: "/work/alpha"}, r, "")
+	})
+	sessions.Upsert(sid, func(s *session.Session) {
+		p.applyRepoResolution(s, &parser.Event{CWD: "/work/beta/deep/subdir"}, r, "")
+	})
+	sess, _ := sessions.Get(sid)
+	if sess.CWD != "/work/alpha" {
+		t.Errorf("CWD drifted: got %q, want /work/alpha (start cwd, never overwritten)", sess.CWD)
+	}
+}
+
+// TestProcess_ChildInheritsParentRepo is an end-to-end check that a subagent
+// running in a git worktree inherits its PARENT's repo_id instead of minting a
+// phantom "agent-<hash>" repo from its own worktree directory basename.
+func TestProcess_ChildInheritsParentRepo(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const parentID = "parent-session"
+	const childID = "agent-deadbeefcafef00d" // worktree-style stem
+
+	// Seed the parent's repo_id directly so resolution is deterministic and does
+	// not shell out to git. The pipeline looks this up via the live session store.
+	sessions.Upsert(parentID, func(s *session.Session) {
+		s.RepoID = "github.com/acme/widget"
+		s.SetRepoSourceRank(repo.SourceGitRemote)
+	})
+
+	// Child event from a worktree whose basename would otherwise resolve to a
+	// phantom "agent-deadbeef" repo. isSidechain + in-content sessionId names the
+	// parent (resolveParentID shape-2 path).
+	childLine := makeJSONL(t, map[string]interface{}{
+		"type":        "assistant",
+		"timestamp":   time.Now().Format(time.RFC3339Nano),
+		"sessionId":   parentID, // in-content sessionId names the true parent
+		"isSidechain": true,
+		"cwd":         "/work/.worktrees/agent-deadbeefcafef00d",
+		"message": map[string]interface{}{
+			"id":          "cmsg-1",
+			"role":        "assistant",
+			"content":     "child work",
+			"stop_reason": "end_turn",
+		},
+	})
+
+	p.Process(watcher.Event{SessionID: childID, Line: childLine})
+
+	child, ok := sessions.Get(childID)
+	if !ok {
+		t.Fatal("child session not found")
+	}
+	if child.ParentID != parentID {
+		t.Fatalf("child ParentID = %q, want %q", child.ParentID, parentID)
+	}
+	if child.RepoID != "github.com/acme/widget" {
+		t.Errorf("child RepoID = %q, want inherited parent repo github.com/acme/widget", child.RepoID)
+	}
+	if strings.Contains(child.RepoID, "agent-") {
+		t.Errorf("child RepoID = %q is a phantom agent-* repo; should inherit parent", child.RepoID)
+	}
+}
+
+// TestProcess_ChildInheritsParentRepoFromDB verifies the inheritance falls back to
+// the persisted sessions table when the parent is not in the live store (e.g. the
+// parent was flushed in an earlier run or replayed out of order).
+func TestProcess_ChildInheritsParentRepoFromDB(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const parentID = "db-parent-session"
+	const childID = "agent-feedface12345678"
+
+	// Persist the parent to the DB ONLY (absent from the live store).
+	if err := db.SaveSession(&session.Session{ID: parentID, RepoID: "github.com/acme/gadget"}); err != nil {
+		t.Fatalf("SaveSession parent: %v", err)
+	}
+
+	childLine := makeJSONL(t, map[string]interface{}{
+		"type":        "assistant",
+		"timestamp":   time.Now().Format(time.RFC3339Nano),
+		"sessionId":   parentID,
+		"isSidechain": true,
+		"cwd":         "/work/.worktrees/agent-feedface12345678",
+		"message": map[string]interface{}{
+			"id":          "cmsg-2",
+			"role":        "assistant",
+			"content":     "child work",
+			"stop_reason": "end_turn",
+		},
+	})
+
+	p.Process(watcher.Event{SessionID: childID, Line: childLine})
+
+	child, ok := sessions.Get(childID)
+	if !ok {
+		t.Fatal("child session not found")
+	}
+	if child.RepoID != "github.com/acme/gadget" {
+		t.Errorf("child RepoID = %q, want inherited-from-DB parent repo github.com/acme/gadget", child.RepoID)
+	}
+}
+
+// TestProcess_ChildBeforeParent_BackfillsRepo verifies the child-before-parent
+// ordering: a subagent whose event arrives BEFORE its parent's first resolves its
+// own (worktree) cwd to a phantom repo, but once the parent arrives the deferred
+// link wiring re-points the child at the parent's project.
+func TestProcess_ChildBeforeParent_BackfillsRepo(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const parentID = "bp-parent-uuid"
+	const childID = "agent-00ff00ff00ff00ff"
+	ts := time.Now()
+
+	// Pre-seed the child with a phantom repo to simulate its own-cwd resolution
+	// having already happened (the parent was unknown at that point). Use the
+	// deferred-link path via parentUuid so the child's ParentID is NOT set yet.
+	sessions.Upsert(childID, func(s *session.Session) {
+		s.RepoID = "agent-00ff00ff" // phantom worktree repo
+		s.SetRepoSourceRank(repo.SourceGitToplevel)
+	})
+
+	childLine := makeJSONL(t, map[string]interface{}{
+		"type":        "assistant",
+		"timestamp":   ts.Format(time.RFC3339Nano),
+		"sessionId":   childID,
+		"parentUuid":  parentID,
+		"isSidechain": true,
+		"message": map[string]interface{}{
+			"id":          "bp-cmsg-1",
+			"role":        "assistant",
+			"content":     "child",
+			"stop_reason": "end_turn",
+		},
+	})
+	p.Process(watcher.Event{SessionID: childID, Line: childLine, Bootstrap: true})
+
+	// Parent not present yet -> link deferred, child keeps its phantom repo.
+	child, _ := sessions.Get(childID)
+	if child.ParentID != "" {
+		t.Fatalf("child ParentID should be deferred (empty); got %q", child.ParentID)
+	}
+
+	// Parent arrives with a real repo.
+	sessions.Upsert(parentID, func(s *session.Session) {
+		s.RepoID = "github.com/acme/widget"
+		s.SetRepoSourceRank(repo.SourceGitRemote)
+	})
+	parentLine := makeJSONL(t, map[string]interface{}{
+		"type":      "assistant",
+		"timestamp": ts.Add(time.Second).Format(time.RFC3339Nano),
+		"sessionId": parentID,
+		"message": map[string]interface{}{
+			"id":          "bp-pmsg-1",
+			"role":        "assistant",
+			"content":     "parent",
+			"stop_reason": "end_turn",
+		},
+	})
+	p.Process(watcher.Event{SessionID: parentID, Line: parentLine, Bootstrap: true})
+
+	child, _ = sessions.Get(childID)
+	if child.ParentID != parentID {
+		t.Fatalf("child ParentID = %q, want %q after parent arrival", child.ParentID, parentID)
+	}
+	if child.RepoID != "github.com/acme/widget" {
+		t.Errorf("child RepoID = %q, want back-filled parent repo github.com/acme/widget", child.RepoID)
+	}
+}
+
+// TestSameRepo verifies the same-repo decision used to gate start-pin upgrades.
+func TestSameRepo(t *testing.T) {
+	mk := func(top string) *repo.Repo { return &repo.Repo{Toplevel: top} }
+	cases := []struct {
+		name       string
+		pinnedTop  string
+		startCWD   string
+		incoming   *repo.Repo
+		newCWD     string
+		want       bool
+	}{
+		{"identical toplevels", "/work/widget", "", mk("/work/widget"), "", true},
+		{"nested toplevel (start subdir)", "/work/mono/pkg", "", mk("/work/mono"), "", true},
+		{"different repos", "/work/alpha", "", mk("/work/beta"), "", false},
+		{"prefix-but-not-path (/repo vs /repo2)", "/work/repo", "", mk("/work/repo2"), "", false},
+		{"incoming has no toplevel", "/work/widget", "", mk(""), "", false},
+		{"fallback pin, start cwd inside incoming toplevel", "", "/work/widget/src", mk("/work/widget"), "", true},
+		{"fallback pin, start cwd outside incoming toplevel", "", "/elsewhere/foo", mk("/work/widget"), "", false},
+		{"fallback pin, no start cwd, new cwd inside toplevel", "", "", mk("/work/widget"), "/work/widget/cmd", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &session.Session{CWD: tc.startCWD}
+			s.SetRepoToplevel(tc.pinnedTop)
+			if got := sameRepo(s, tc.incoming, tc.newCWD); got != tc.want {
+				t.Errorf("sameRepo = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -10,6 +10,11 @@ type Repo struct {
 	// runtime-only hint used to upgrade an earlier fallback resolution; it is
 	// NOT persisted.
 	FromGit bool
+	// Toplevel is the absolute git working-tree root for this resolution, when
+	// known (empty for non-git fallbacks). It is a runtime-only hint used to
+	// decide whether a later resolution refers to the SAME repository as the
+	// session's pinned one (start-pin upgrade), and is NOT persisted.
+	Toplevel string
 }
 
 // Resolution-authority ranks, used to decide whether a later resolution should

--- a/internal/repo/resolver.go
+++ b/internal/repo/resolver.go
@@ -56,16 +56,20 @@ func (r *Resolver) Resolve(cwd, label string) (*Repo, error) {
 }
 
 func (r *Resolver) resolve(cwd, label string) *Repo {
-	// Try git remote origin
+	// Try git remote origin. Also capture the working-tree root (toplevel) so
+	// callers can recognise when a later resolution refers to the SAME repo
+	// (used for start-pinned repo_id upgrades). A toplevel lookup failure is
+	// non-fatal — the remote URL still uniquely identifies the repo.
 	if rawURL, err := gitRemoteURL(cwd); err == nil && rawURL != "" {
 		id, name, fullURL := normalizeRemoteURL(rawURL)
-		return &Repo{ID: id, Name: name, URL: fullURL, FromGit: true}
+		toplevel, _ := gitToplevel(cwd)
+		return &Repo{ID: id, Name: name, URL: fullURL, FromGit: true, Toplevel: toplevel}
 	}
 
 	// Fallback: git toplevel basename
 	if toplevel, err := gitToplevel(cwd); err == nil && toplevel != "" {
 		base := filepath.Base(toplevel)
-		return &Repo{ID: base, Name: base, FromGit: true}
+		return &Repo{ID: base, Name: base, FromGit: true, Toplevel: toplevel}
 	}
 
 	// Container fallback: label + basename

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -62,6 +62,7 @@ type Session struct {
 	AgentKind      string           `json:"agentKind,omitempty"`  // session | subagent | workflow_agent
 	SourceFile     string           `json:"-"` // JSONL file path currently providing events (not serialized)
 	repoSourceRank int              `json:"-"` // resolution-authority rank of RepoID (repo.Source*); runtime-only, not persisted
+	repoToplevel   string           `json:"-"` // git working-tree root of the pinned RepoID; runtime-only, used to detect SAME-repo upgrades, not persisted
 }
 
 // RepoSourceRank reports the resolution-authority rank of the current RepoID
@@ -70,6 +71,14 @@ func (s *Session) RepoSourceRank() int { return s.repoSourceRank }
 
 // SetRepoSourceRank records the resolution-authority rank of the current RepoID.
 func (s *Session) SetRepoSourceRank(rank int) { s.repoSourceRank = rank }
+
+// RepoToplevel reports the git working-tree root that the current RepoID was
+// resolved from (empty for non-git fallbacks). Used to decide whether a later
+// resolution refers to the SAME repository as the start-pinned one.
+func (s *Session) RepoToplevel() string { return s.repoToplevel }
+
+// SetRepoToplevel records the git working-tree root of the current RepoID.
+func (s *Session) SetRepoToplevel(toplevel string) { s.repoToplevel = toplevel }
 
 // RepoFromGit reports whether the current RepoID came from an authoritative git
 // resolution (git remote or toplevel), as opposed to a non-git fallback.

--- a/internal/store/audit_fixes_test.go
+++ b/internal/store/audit_fixes_test.go
@@ -291,14 +291,25 @@ func TestMigration015_RecomputeAggregates(t *testing.T) {
 		t.Fatalf("corrupt session failed: %v", err)
 	}
 
-	// Re-run migration 015 (and 016) by rolling back to <15 then re-applying.
-	if _, err := migrations.RunDown(db.db); err != nil { // 16 -> 15
-		t.Fatalf("RunDown 16 failed: %v", err)
+	// Re-run migration 015 by rolling the version back below 15 (rolling back
+	// every migration stacked on top of it generically, so this stays valid as
+	// later migrations are added) then re-applying to head.
+	rollbackBelow15 := func() {
+		for {
+			v, err := migrations.GetVersion(db.db)
+			if err != nil {
+				t.Fatalf("GetVersion failed: %v", err)
+			}
+			if v < 15 {
+				return
+			}
+			if _, err := migrations.RunDown(db.db); err != nil {
+				t.Fatalf("RunDown from v%d failed: %v", v, err)
+			}
+		}
 	}
-	if _, err := migrations.RunDown(db.db); err != nil { // 15 -> 14
-		t.Fatalf("RunDown 15 failed: %v", err)
-	}
-	if _, err := migrations.RunUp(db.db); err != nil { // re-applies 15 + 16
+	rollbackBelow15()
+	if _, err := migrations.RunUp(db.db); err != nil { // re-applies 15 and everything above
 		t.Fatalf("RunUp failed: %v", err)
 	}
 
@@ -321,12 +332,7 @@ func TestMigration015_RecomputeAggregates(t *testing.T) {
 	}
 
 	// Idempotency: running the recompute SQL again must not change the values.
-	if _, err := migrations.RunDown(db.db); err != nil {
-		t.Fatalf("RunDown(idempotency) failed: %v", err)
-	}
-	if _, err := migrations.RunDown(db.db); err != nil {
-		t.Fatalf("RunDown(idempotency) failed: %v", err)
-	}
+	rollbackBelow15()
 	if _, err := migrations.RunUp(db.db); err != nil {
 		t.Fatalf("RunUp(idempotency) failed: %v", err)
 	}

--- a/internal/store/migrations/017_reattribute_child_repos.go
+++ b/internal/store/migrations/017_reattribute_child_repos.go
@@ -1,0 +1,63 @@
+package migrations
+
+import "database/sql"
+
+func init() {
+	Register(17, Migration{
+		Name: "reattribute_child_repos",
+		Up: func(tx *sql.Tx) error {
+			// Mirror the new write-path rule (pipeline.applyRepoResolution rule 1):
+			// a child session inherits its PARENT's repo_id. Historically, subagents
+			// running in git worktrees resolved their own worktree directory and were
+			// attributed to phantom "agent-<hash>" repos, fragmenting a parent run
+			// across fake projects. Re-point each child at its parent's project.
+			//
+			// Iterate to a fixpoint so multi-level chains (a subagent that spawns its
+			// own subagent) propagate the root project down every level. Each pass
+			// uses the parent's CURRENT repo_id (SQLite evaluates the UPDATE against
+			// pre-statement values), so up to depth passes are needed; the loop stops
+			// as soon as a pass changes nothing. Bounded by maxPasses as a safety net
+			// against any pathological parent cycle (which the write path cannot
+			// create, but defensive code is cheap here).
+			//
+			// Idempotent: once every child equals its parent's repo_id, the first pass
+			// affects zero rows and the loop exits. Re-running the migration is a no-op.
+			const maxPasses = 64
+			for i := 0; i < maxPasses; i++ {
+				res, err := tx.Exec(`
+					UPDATE sessions
+					SET repo_id = (
+						SELECT p.repo_id FROM sessions p
+						WHERE p.id = sessions.parent_id
+					)
+					WHERE parent_id IS NOT NULL
+					  AND parent_id != ''
+					  AND EXISTS (
+						SELECT 1 FROM sessions p
+						WHERE p.id = sessions.parent_id
+						  AND COALESCE(p.repo_id,'') != ''
+						  AND COALESCE(p.repo_id,'') != COALESCE(sessions.repo_id,'')
+					)
+				`)
+				if err != nil {
+					return err
+				}
+				n, err := res.RowsAffected()
+				if err != nil {
+					return err
+				}
+				if n == 0 {
+					break
+				}
+			}
+			return nil
+		},
+		Down: func(tx *sql.Tx) error {
+			// This migration only re-points historical child sessions to match the
+			// canonical write-path attribution. The prior phantom "agent-*" repo_ids
+			// were incorrect, so there is no meaningful inverse to restore. No-op so
+			// rollback does not re-introduce the fragmentation.
+			return nil
+		},
+	})
+}

--- a/internal/store/migrations/registry_test.go
+++ b/internal/store/migrations/registry_test.go
@@ -247,9 +247,9 @@ func TestOpus48Pricing_SeededAndReversible(t *testing.T) {
 		t.Errorf("cache_create_per_mtok = %v, want 6.25", cacheCreate)
 	}
 
-	// Roll back the migrations above 014 (016 then 015) so 014 becomes the head,
+	// Roll back the migrations above 014 (newest first) so 014 becomes the head,
 	// then roll back 014 itself.
-	for _, want := range []string{"rebuild_events_fts", "recompute_session_aggregates"} {
+	for _, want := range []string{"reattribute_child_repos", "rebuild_events_fts", "recompute_session_aggregates"} {
 		name, err := RunDown(db)
 		if err != nil {
 			t.Fatalf("RunDown: %v", err)
@@ -354,6 +354,82 @@ func TestFailedMigration_RollsBack(t *testing.T) {
 	}
 	if v != 1 {
 		t.Errorf("expected version 1 after failed migration 2, got %d", v)
+	}
+}
+
+// TestMigration017_ReattributesChildRepos runs the REAL registry to head, then
+// re-applies migration 017 against populated data (by rolling its version back to
+// 16 and running up again) to verify children — including a multi-level chain —
+// are re-pointed at their parent's repo_id, root sessions are left alone, and a
+// second application is a no-op (idempotent).
+func TestMigration017_ReattributesChildRepos(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("RunUp: %v", err)
+	}
+
+	// Seed sessions AFTER the initial RunUp (so 017's first pass saw an empty
+	// table). A root in a real repo, a child with a phantom worktree repo, and a
+	// grandchild with its own phantom repo. parent_repo is a sibling root in a
+	// different project that must be untouched.
+	seed := func(id, parentID, repoID string) {
+		t.Helper()
+		if _, err := db.Exec(
+			`INSERT INTO sessions (id, parent_id, repo_id) VALUES (?, ?, ?)`,
+			id, parentID, repoID,
+		); err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+	seed("root", "", "github.com/acme/widget")
+	seed("child", "root", "agent-deadbeef")       // phantom worktree repo
+	seed("grandchild", "child", "agent-cafef00d") // phantom, one level deeper
+	seed("other-root", "", "github.com/acme/other")
+
+	// Re-apply 017 against the now-populated table: roll its version back to 16
+	// (Down is a no-op, leaving rows intact) then RunUp re-applies just 017.
+	if _, err := RunDown(db); err != nil {
+		t.Fatalf("RunDown 017: %v", err)
+	}
+	if v, _ := GetVersion(db); v != 16 {
+		t.Fatalf("after RunDown: version = %d, want 16", v)
+	}
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("re-RunUp (applies 017): %v", err)
+	}
+
+	repoOf := func(id string) string {
+		t.Helper()
+		var r string
+		if err := db.QueryRow(`SELECT COALESCE(repo_id,'') FROM sessions WHERE id = ?`, id).Scan(&r); err != nil {
+			t.Fatalf("read repo of %s: %v", id, err)
+		}
+		return r
+	}
+
+	if got := repoOf("child"); got != "github.com/acme/widget" {
+		t.Errorf("child repo = %q, want inherited github.com/acme/widget", got)
+	}
+	// Multi-level: grandchild should propagate up to the root project via the fixpoint loop.
+	if got := repoOf("grandchild"); got != "github.com/acme/widget" {
+		t.Errorf("grandchild repo = %q, want propagated github.com/acme/widget", got)
+	}
+	if got := repoOf("root"); got != "github.com/acme/widget" {
+		t.Errorf("root repo = %q, want unchanged github.com/acme/widget", got)
+	}
+	if got := repoOf("other-root"); got != "github.com/acme/other" {
+		t.Errorf("other-root repo = %q, want unchanged github.com/acme/other", got)
+	}
+
+	// Idempotent: rolling back and re-applying again must yield identical results.
+	if _, err := RunDown(db); err != nil {
+		t.Fatalf("RunDown 017 (2nd): %v", err)
+	}
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("re-RunUp 017 (2nd): %v", err)
+	}
+	if got := repoOf("grandchild"); got != "github.com/acme/widget" {
+		t.Errorf("after 2nd apply: grandchild repo = %q, want github.com/acme/widget", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Hardens how a session's project (`repo_id`) and displayed working directory are attributed in the event pipeline. Three fixes:

### 1. Strict start-pin for `repo_id`
Previously `repo_id` was upgraded whenever a later event resolved at a strictly higher source rank — **even for a different repository**. A session that started in project A (e.g. git-remote lookup timed out → toplevel basename) and later `cd`'d into project B (git remote, higher rank) had its project flipped to B.

Now a session stays pinned to its **start** project. A higher-authority resolution may only upgrade the resolution **quality of the same repository** (e.g. toplevel-basename → git-remote id for the same checkout), never switch projects. "Same repo" is determined conservatively (`sameRepo`):
- identical git working-tree roots, or one nested within the other; else
- the session's start cwd lives inside the incoming resolution's toplevel (covers the headline case: start cwd's remote lookup timed out → basename fallback, later resolved to the real git id).

When in doubt, the original pin is kept. `repo.Repo` gains a runtime-only `Toplevel`; `session.Session` gains a runtime-only `repoToplevel` (neither persisted).

### 2. Child sessions inherit the parent's project
A session with a known parent inherits the parent's `repo_id` (looked up from the live session store, falling back to the persisted `sessions` table) instead of resolving its own worktree cwd — which used to mint phantom `agent-<hash>` repos and fragment a parent run across fake projects. The parent's `repo_id` is pre-resolved **outside** the session-store lock to avoid re-entrancy. Deferred child→parent links (child-before-parent ordering) also back-fill the inherited repo when the parent arrives. Falls back to normal resolution only when the parent is unknown.

### 3. Stable start cwd
`Session.CWD` is now set once (first event carrying a cwd) and never overwritten, so a card's displayed directory reflects session start and cannot drift after a `cd`. Repo resolution still uses the per-event cwd, so attribution is unaffected.

### Migration
Adds **017 `reattribute_child_repos`**: idempotently re-points existing child sessions' `repo_id` to their parent's, mirroring the new write-path rule, iterating to a fixpoint for multi-level subagent chains. `Down` is a no-op (the prior phantom ids were incorrect; no meaningful inverse).

## Test coverage
- `TestApplyRepoResolution_StartPin_NoFlipToDifferentRepo` — start-pin does not flip to a higher-rank different repo.
- `TestApplyRepoResolution_StartPin_UpgradesSameRepoSubdir` — legitimate same-repo (incl. nested subdir) upgrade preserved.
- `TestApplyRepoResolution_CWDStaysAtStart` — cwd stays at session start.
- `TestProcess_ChildInheritsParentRepo` / `...FromDB` — child inherits parent repo from live store and from DB; no `agent-*` phantom.
- `TestProcess_ChildBeforeParent_BackfillsRepo` — deferred-link back-fill.
- `TestSameRepo` — same-repo decision edge cases (identical/nested/different toplevels, prefix-not-path, fallback-pin via start cwd).
- `TestMigration017_ReattributesChildRepos` — re-attribution incl. multi-level chain + idempotency.
- Existing `applyRepoResolution` tests updated for the new same-repo gating; two brittle migration tests (`TestMigration015`, `TestOpus48Pricing_SeededAndReversible`) made head-version-agnostic.

## Validation
- `go build ./...` — OK
- `go vet ./...` — OK
- `TZ=UTC go test ./... -count=1` — all packages pass
- `TZ=America/Vancouver go test ./internal/store/... ./internal/pipeline/... -count=1` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)