### PR TITLE
fix: harden repo-attribution follow-ups from #233 review

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -104,10 +104,15 @@ func (p *Pipeline) resolvePendingLinks() {
 				// (worktree) cwd to a phantom repo because the parent was unknown.
 				// Now that the parent exists, re-point the child at the parent's
 				// project, mirroring applyRepoResolution's rule 1.
-				if parentRepoID != "" && s.RepoID != parentRepoID {
-					s.RepoID = parentRepoID
-					s.SetRepoSourceRank(repo.SourceGitRemote)
-					s.SetRepoToplevel("")
+				if parentRepoID != "" {
+					// The pin is now inherited — flag it so subsequent flushes don't
+					// persist this child's worktree cwd → parent repo in cwd_repos.
+					s.SetRepoInherited(true)
+					if s.RepoID != parentRepoID {
+						s.RepoID = parentRepoID
+						s.SetRepoSourceRank(repo.SourceGitRemote)
+						s.SetRepoToplevel("")
+					}
 				}
 			})
 			p.sessions.LinkChild(parentUUID, childID)
@@ -334,10 +339,21 @@ func (p *Pipeline) applyWorkflowIdentity(s *session.Session, ev watcher.Event) {
 //  3. CWD is set once (session start) and never overwritten — see below.
 func (p *Pipeline) applyRepoResolution(s *session.Session, msg *parser.Event, r *repo.Repo, parentRepoID string) {
 	// Rule 1: inherit the parent's project. parentRepoID is non-empty only when
-	// this session has a known parent with a resolved repo_id. Set-once so we
-	// don't thrash if the parent's id later changes; the child stays pinned to
-	// whatever the parent was attributed to at first sight.
+	// this session has a known parent with a resolved repo_id. The child mirrors
+	// the parent's CURRENT repo_id on every event — it is NOT set-once: if the
+	// parent's own pin is later upgraded for the same checkout (e.g. a
+	// toplevel-basename id replaced by the git-remote id), the next child event
+	// re-points the child to follow it. The s.RepoID != parentRepoID guard only
+	// skips a redundant write when they already agree. Start-pin (rule 2) keeps
+	// the parent from flipping to a DIFFERENT repo, so this tracking can only
+	// ever follow a same-repo quality upgrade, never a project switch.
 	if parentRepoID != "" {
+		// Mark the pin as inherited so the flush path skips recording this child's
+		// (worktree) cwd → inherited repo_id in cwd_repos. That cwd belongs to the
+		// child's own working tree, not the parent's project, and persisting the
+		// mapping would mis-attribute future unrelated sessions that resolve the
+		// same directory.
+		s.SetRepoInherited(true)
 		if s.RepoID != parentRepoID {
 			s.RepoID = parentRepoID
 			// Mark as git-remote authority: an inherited id is as trustworthy as
@@ -405,9 +421,13 @@ func (p *Pipeline) applyRepoResolution(s *session.Session, msg *parser.Event, r 
 // evidence, so an ambiguous case keeps the original pinned repo.
 //
 // Evidence, strongest first:
-//   - identical git working-tree roots (the pinned and new resolutions are in
-//     the same checkout), or one toplevel nested within the other (e.g. the
-//     start cwd was a subdir of the new toplevel, or vice versa); or
+//   - both sides git-backed: the incoming working-tree root is the pinned one,
+//     or is NESTED WITHIN it (same-or-narrower). Two resolutions of the same
+//     checkout always share a toplevel — git normalises any subdir to the repo
+//     root — so the headline case is equality. The reverse direction is rejected
+//     on purpose: an incoming toplevel that CONTAINS the pin is a WIDER repo
+//     (e.g. the outer monorepo of a nested inner checkout), and letting an inner
+//     project flip up to its enclosing repo would violate the start-pin.
 //   - the session has no recorded toplevel (its pin came from a non-git fallback,
 //     i.e. git was unavailable at start) but the new resolution's toplevel
 //     contains the session's START cwd. That is the headline upgrade case: the
@@ -422,8 +442,11 @@ func sameRepo(s *session.Session, r *repo.Repo, newCWD string) bool {
 		return false
 	}
 	if top := s.RepoToplevel(); top != "" {
-		// Both sides are git-backed: compare working-tree roots directly.
-		return pathContains(top, r.Toplevel) || pathContains(r.Toplevel, top)
+		// Both sides are git-backed. Same repo only when the incoming root is the
+		// pinned one or nested inside it. A wider incoming root that CONTAINS the
+		// pin (an outer monorepo) is a different, enclosing project — reject it so
+		// the inner pin cannot flip outward.
+		return pathContains(top, r.Toplevel)
 	}
 	// The pin is a non-git fallback (no toplevel). Use the session's start cwd:
 	// if it lives inside the incoming resolution's working tree, this is a

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1523,6 +1523,82 @@ func TestProcess_ChildInheritsParentRepo(t *testing.T) {
 	}
 }
 
+// TestProcess_ChildTracksParentRepoChange guards the SYNCHRONOUS inheritance path
+// (parent already in the live store when the child event arrives) and, in
+// particular, that Rule 1 is NOT set-once: the child mirrors the parent's CURRENT
+// repo_id on every event. A redundant event must not thrash the pin back to the
+// child's own worktree cwd, and a later same-repo QUALITY upgrade on the parent
+// (toplevel-basename id → git-remote id) must propagate to the child.
+func TestProcess_ChildTracksParentRepoChange(t *testing.T) {
+	db := openTestDB(t)
+	sessions := session.NewStore()
+	resolver := repo.NewResolver()
+	p := New(sessions, db, resolver, nil)
+	defer p.Stop()
+
+	const parentID = "track-parent-session"
+	const childID = "agent-1234567890abcdef" // worktree-style stem
+
+	// Parent starts pinned to a low-authority toplevel-basename id.
+	sessions.Upsert(parentID, func(s *session.Session) {
+		s.RepoID = "widget"
+		s.SetRepoSourceRank(repo.SourceGitToplevel)
+	})
+
+	// A child event from the worktree, naming the parent via in-content sessionId
+	// + isSidechain (resolveParentID shape-2). Distinct message ids avoid dedup.
+	childEvent := func(msgID string) watcher.Event {
+		line := makeJSONL(t, map[string]interface{}{
+			"type":        "assistant",
+			"timestamp":   time.Now().Format(time.RFC3339Nano),
+			"sessionId":   parentID,
+			"isSidechain": true,
+			"cwd":         "/work/.worktrees/agent-1234567890abcdef",
+			"message": map[string]interface{}{
+				"id":          msgID,
+				"role":        "assistant",
+				"content":     "child work",
+				"stop_reason": "end_turn",
+			},
+		})
+		return watcher.Event{SessionID: childID, Line: line}
+	}
+
+	// Event 1: child inherits the parent's current pin synchronously.
+	p.Process(childEvent("track-c1"))
+	child, ok := sessions.Get(childID)
+	if !ok {
+		t.Fatal("child session not found")
+	}
+	if child.RepoID != "widget" {
+		t.Fatalf("after first event: child RepoID = %q, want inherited widget", child.RepoID)
+	}
+	if strings.Contains(child.RepoID, "agent-") {
+		t.Fatalf("child RepoID = %q is a phantom worktree repo; should inherit parent", child.RepoID)
+	}
+
+	// Event 2: parent unchanged → child stays pinned and does NOT thrash back to
+	// its own worktree cwd phantom.
+	p.Process(childEvent("track-c2"))
+	child, _ = sessions.Get(childID)
+	if child.RepoID != "widget" {
+		t.Errorf("after redundant event: child RepoID = %q, want still widget (no thrash)", child.RepoID)
+	}
+
+	// Parent's own pin is upgraded for the SAME checkout (basename → git-remote).
+	sessions.Upsert(parentID, func(s *session.Session) {
+		s.RepoID = "github.com/acme/widget"
+		s.SetRepoSourceRank(repo.SourceGitRemote)
+	})
+
+	// Event 3: child tracks the parent's CURRENT id (Rule 1 is not set-once).
+	p.Process(childEvent("track-c3"))
+	child, _ = sessions.Get(childID)
+	if child.RepoID != "github.com/acme/widget" {
+		t.Errorf("after parent upgrade: child RepoID = %q, want tracked github.com/acme/widget", child.RepoID)
+	}
+}
+
 // TestProcess_ChildInheritsParentRepoFromDB verifies the inheritance falls back to
 // the persisted sessions table when the parent is not in the live store (e.g. the
 // parent was flushed in an earlier run or replayed out of order).
@@ -1649,7 +1725,12 @@ func TestSameRepo(t *testing.T) {
 		want       bool
 	}{
 		{"identical toplevels", "/work/widget", "", mk("/work/widget"), "", true},
-		{"nested toplevel (start subdir)", "/work/mono/pkg", "", mk("/work/mono"), "", true},
+		// Direction guard: a narrower incoming root nested inside the pin is the
+		// same (or a more-specific) checkout and may upgrade; a wider incoming
+		// root that CONTAINS the pin is the enclosing monorepo and must NOT let
+		// the inner pin flip outward.
+		{"incoming nested within pin (narrower) -> same", "/work/mono", "", mk("/work/mono/pkg"), "", true},
+		{"incoming contains pin (outer monorepo) -> different", "/work/mono/pkg", "", mk("/work/mono"), "", false},
 		{"different repos", "/work/alpha", "", mk("/work/beta"), "", false},
 		{"prefix-but-not-path (/repo vs /repo2)", "/work/repo", "", mk("/work/repo2"), "", false},
 		{"incoming has no toplevel", "/work/widget", "", mk(""), "", false},

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -63,6 +63,7 @@ type Session struct {
 	SourceFile     string           `json:"-"` // JSONL file path currently providing events (not serialized)
 	repoSourceRank int              `json:"-"` // resolution-authority rank of RepoID (repo.Source*); runtime-only, not persisted
 	repoToplevel   string           `json:"-"` // git working-tree root of the pinned RepoID; runtime-only, used to detect SAME-repo upgrades, not persisted
+	repoInherited  bool             `json:"-"` // RepoID was inherited from the parent (not resolved from this session's own cwd); runtime-only, not persisted
 }
 
 // RepoSourceRank reports the resolution-authority rank of the current RepoID
@@ -79,6 +80,16 @@ func (s *Session) RepoToplevel() string { return s.repoToplevel }
 
 // SetRepoToplevel records the git working-tree root of the current RepoID.
 func (s *Session) SetRepoToplevel(toplevel string) { s.repoToplevel = toplevel }
+
+// RepoInherited reports whether RepoID was inherited from this session's parent
+// (a child/subagent that took the parent's project) rather than resolved from
+// its own cwd. The flush path uses this to skip persisting the child's worktree
+// cwd → inherited repo_id in cwd_repos, which would otherwise mis-attribute
+// future unrelated sessions resolving the same directory.
+func (s *Session) RepoInherited() bool { return s.repoInherited }
+
+// SetRepoInherited records whether the current RepoID was inherited from a parent.
+func (s *Session) SetRepoInherited(v bool) { s.repoInherited = v }
 
 // RepoFromGit reports whether the current RepoID came from an authoritative git
 // resolution (git remote or toplevel), as opposed to a non-git fallback.

--- a/internal/store/migrations/017_reattribute_child_repos.go
+++ b/internal/store/migrations/017_reattribute_child_repos.go
@@ -13,12 +13,20 @@ func init() {
 			// across fake projects. Re-point each child at its parent's project.
 			//
 			// Iterate to a fixpoint so multi-level chains (a subagent that spawns its
-			// own subagent) propagate the root project down every level. Each pass
-			// uses the parent's CURRENT repo_id (SQLite evaluates the UPDATE against
-			// pre-statement values), so up to depth passes are needed; the loop stops
-			// as soon as a pass changes nothing. Bounded by maxPasses as a safety net
-			// against any pathological parent cycle (which the write path cannot
-			// create, but defensive code is cheap here).
+			// own subagent) propagate the root project down every level, for any
+			// physical row order.
+			//
+			// Within a SINGLE UPDATE, SQLite walks rows in rowid order and a
+			// correlated subquery reads values written EARLIER in that same statement
+			// — it is NOT a pre-statement snapshot. So when a parent's row precedes
+			// its child's in rowid order, one pass already cascades the entire chain
+			// (the child reads the parent's freshly-written id, the grandchild reads
+			// the child's, and so on). But when a child precedes its parent (rows
+			// inserted or replayed out of depth order), each pass advances a chain by
+			// only one level. The loop runs until a pass changes nothing, which
+			// converges either way. Bounded by maxPasses as a safety net against a
+			// pathological parent cycle (which the write path cannot create, but
+			// defensive code is cheap here).
 			//
 			// Idempotent: once every child equals its parent's repo_id, the first pass
 			// affects zero rows and the loop exits. Re-running the migration is a no-op.

--- a/internal/store/migrations/registry_test.go
+++ b/internal/store/migrations/registry_test.go
@@ -381,9 +381,16 @@ func TestMigration017_ReattributesChildRepos(t *testing.T) {
 			t.Fatalf("seed %s: %v", id, err)
 		}
 	}
-	seed("root", "", "github.com/acme/widget")
-	seed("child", "root", "agent-deadbeef")       // phantom worktree repo
+	// Insert in REVERSE depth order (grandchild, then child, then root) so the
+	// child/grandchild rows get LOWER rowids than their parents. SQLite walks an
+	// UPDATE in rowid order reading values written earlier in the same statement,
+	// so this ordering means a single pass advances each chain by only one level —
+	// the grandchild genuinely requires the fixpoint loop's second pass to reach
+	// the root project. (With the natural parent-first order, one pass would
+	// cascade the whole chain and the multi-pass loop would never be exercised.)
 	seed("grandchild", "child", "agent-cafef00d") // phantom, one level deeper
+	seed("child", "root", "agent-deadbeef")       // phantom worktree repo
+	seed("root", "", "github.com/acme/widget")
 	seed("other-root", "", "github.com/acme/other")
 
 	// Re-apply 017 against the now-populated table: roll its version back to 16

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -491,7 +491,11 @@ func (d *DB) FlushSessions(sessions []*session.Session) error {
 			return fmt.Errorf("FlushSessions save %s: %w", s.ID, err)
 		}
 
-		if s.CWD != "" && s.RepoID != "" {
+		// Skip inherited child pins: their cwd is the child's own (worktree)
+		// directory, not the parent's project, so recording cwd → inherited
+		// repo_id would mis-attribute future unrelated sessions resolving the
+		// same directory after a restart seeds the resolver cache from this table.
+		if s.CWD != "" && s.RepoID != "" && !s.RepoInherited() {
 			if _, err := cwdStmt.Exec(s.CWD, s.RepoID); err != nil {
 				return fmt.Errorf("FlushSessions cwdRepo %s: %w", s.ID, err)
 			}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -200,6 +200,44 @@ func TestCwdRepos(t *testing.T) {
 	}
 }
 
+// TestFlushSessions_SkipsCwdRepoForInheritedPins verifies that a child session
+// whose repo_id was inherited from its parent does NOT get its (worktree) cwd
+// recorded in cwd_repos, while a normally-resolved session does. Persisting an
+// inherited child's cwd → repo_id would mis-attribute future unrelated sessions
+// that resolve the same directory once the resolver cache is seeded from this
+// table on restart.
+func TestFlushSessions_SkipsCwdRepoForInheritedPins(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	const repoID = "github.com/acme/widget"
+	if err := db.UpsertRepo(&repo.Repo{ID: repoID, Name: "widget"}); err != nil {
+		t.Fatalf("UpsertRepo: %v", err)
+	}
+
+	// Normally-resolved session: cwd → repo mapping SHOULD be persisted.
+	normal := &session.Session{ID: "normal-sess", CWD: "/work/widget", RepoID: repoID}
+	// Child that inherited its parent's repo: its cwd is the child's own worktree,
+	// not the parent's project, so the mapping must NOT be persisted.
+	child := &session.Session{ID: "child-sess", CWD: "/work/.worktrees/agent-x", RepoID: repoID}
+	child.SetRepoInherited(true)
+
+	if err := db.FlushSessions([]*session.Session{normal, child}); err != nil {
+		t.Fatalf("FlushSessions: %v", err)
+	}
+
+	entries, err := db.LoadCwdRepos()
+	if err != nil {
+		t.Fatalf("LoadCwdRepos: %v", err)
+	}
+	if entries["/work/widget"] != repoID {
+		t.Errorf("normal session cwd mapping = %q, want %q", entries["/work/widget"], repoID)
+	}
+	if got, ok := entries["/work/.worktrees/agent-x"]; ok {
+		t.Errorf("inherited child worktree cwd should not be persisted to cwd_repos; got %q", got)
+	}
+}
+
 func TestSaveSession_InsertAndUpdate(t *testing.T) {
 	t.Parallel()
 	db := openTestDB(t)


### PR DESCRIPTION
Post-merge follow-ups from the #233 review. All four are doc-accuracy + test-strength items — no runtime behaviour changes **except** the two intended fixes (#3 `sameRepo` direction guard, #4 `cwd_repos` skip).

## Changes

**1. Rule 1 "set-once" comment → tracking + synchronous test**
`applyRepoResolution`'s Rule 1 comment claimed inheritance was "set-once… at first sight," but the code (`if s.RepoID != parentRepoID`) re-points a child to the parent's **current** repo_id on every event. Corrected the comment to describe the tracking behaviour and added `TestProcess_ChildTracksParentRepoChange`: inherit on first sight → no thrash on a redundant event → follow a later same-repo quality upgrade (basename → git-remote) on the parent. Existing tests only covered the initial inherit and the child-before-parent back-fill.

**2. Migration 017 fixpoint comment → accurate + reverse-order test**
The comment claimed *"SQLite evaluates the UPDATE against pre-statement values."* Probed empirically against modernc SQLite: it walks rows in **rowid order** and a correlated subquery reads values written **earlier in the same statement** — not a snapshot. So parent-first insertion (the old test's order) cascades a whole chain in a single pass and never exercises the fixpoint loop. Rewrote the comment to match reality and **reversed the seed order** (grandchild→child→root) in `TestMigration017_ReattributesChildRepos` so the grandchild genuinely requires a second pass. (Verified: capping `maxPasses=1` now fails the test.)

**3. `sameRepo` nested-repo direction guard** *(behaviour fix)*
The both-git-backed branch used bidirectional `pathContains`, so an inner repo pinned at `/work/mono/pkg` could flip to its enclosing monorepo `/work/mono` once the outer resolved at a higher rank. Restricted to `pathContains(top, r.Toplevel)` — the incoming root must be the pin or nested *within* it — so an inner pin can no longer flip outward. Updated `TestSameRepo` (old "nested" case now `false`, added the allowed direction).

**4. Skip `cwd_repos` write for inherited child pins** *(behaviour fix)*
A child inheriting its parent's repo_id was writing its own **worktree** cwd → inherited repo_id into `cwd_repos` on flush, which pollutes the resolver cache on restart and mis-attributes future unrelated sessions resolving that directory. Added a runtime-only `Session.repoInherited` flag (set in Rule 1 and the back-fill path) and gated the `FlushSessions` write on `!s.RepoInherited()`. Added `TestFlushSessions_SkipsCwdRepoForInheritedPins`.

## Notes for review
- **`sameRepo` direction:** implemented exactly as the review framed it (*inner can't flip to outer*), which still permits the reverse (an outer pin adopting a nested inner repo on a rank upgrade). If we'd rather forbid any cross-toplevel flip, it's a one-line tightening to `return top == r.Toplevel` — two checkouts of the same repo always share a toplevel, so equality covers every real same-repo case.
- **Historical `cwd_repos` rows:** this fixes the write path going forward. Pre-fix inherited children already have stale worktree→repo rows (worktree dirs are ephemeral, low impact); migration 017 only re-points `sessions.repo_id`. A cleanup migration could follow if wanted.

## Verification
- Each behavioural fix confirmed as a genuine guard by temporarily reverting and watching the test fail.
- `go vet ./...` clean; full suite green (`go test ./...`, 11 packages, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)