### PR TITLE
feat: surface skill & tool usage (feed legibility, analytics, history)

### DIFF
--- a/cmd/claude-monitor/handlers.go
+++ b/cmd/claude-monitor/handlers.go
@@ -308,6 +308,52 @@ func handleStatsTrends(historyDB *store.DB) http.HandlerFunc {
 	}
 }
 
+// handleToolUsage serves GET /api/stats/tools — tool- and skill-invocation
+// counts (with error counts) for the given window and optional repo, scoped by
+// the owning session. Window vocabulary matches /api/stats/trends.
+func handleToolUsage(historyDB *store.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		now := time.Now()
+		var since time.Time
+		switch window := r.URL.Query().Get("window"); window {
+		case "24h":
+			since = now.Add(-24 * time.Hour)
+		case "7d":
+			since = now.AddDate(0, 0, -7)
+		case "30d":
+			since = now.AddDate(0, 0, -30)
+		case "", "all":
+			// lifetime aggregate (since stays zero)
+		default:
+			writeJSONError(w, "window must be 24h, 7d, 30d, or all", http.StatusBadRequest)
+			return
+		}
+
+		usage, err := historyDB.ToolUsage(since, r.URL.Query().Get("repo"))
+		if err != nil {
+			log.Printf("tool usage error: %v", err)
+			writeJSONError(w, "failed to compute tool usage", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, usage)
+	}
+}
+
+// handleSessionSkills serves GET /api/skills/sessions — a sparse map of
+// sessionID → skills invoked (with use/error counts), used by History to badge
+// the rows whose sessions invoked skills.
+func handleSessionSkills(historyDB *store.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		m, err := historyDB.SessionSkills()
+		if err != nil {
+			log.Printf("session skills error: %v", err)
+			writeJSONError(w, "failed to load session skills", http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, m)
+	}
+}
+
 // handleRepos serves GET /api/repos.
 func handleRepos(historyDB *store.DB) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/claude-monitor/main.go
+++ b/cmd/claude-monitor/main.go
@@ -637,6 +637,8 @@ Examples:
 	mux.HandleFunc("GET /api/sessions/{id}", handleSessionByID(sessionStore, historyDB))
 	mux.HandleFunc("GET /api/stats", handleStats(sessionStore, historyDB, fw))
 	mux.HandleFunc("GET /api/stats/trends", handleStatsTrends(historyDB))
+	mux.HandleFunc("GET /api/stats/tools", handleToolUsage(historyDB))
+	mux.HandleFunc("GET /api/skills/sessions", handleSessionSkills(historyDB))
 	mux.HandleFunc("GET /api/repos", handleRepos(historyDB))
 	mux.HandleFunc("GET /api/repos/{id}/stats", handleRepoStats(historyDB))
 	mux.HandleFunc("GET /api/repos/{id}/sessions", handleRepoSessions(historyDB))

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -826,6 +826,122 @@ func (d *DB) AggregateStats(since time.Time) (*AggregateResult, error) {
 	return r, nil
 }
 
+// ToolUsageEntry is one tool or skill with its invocation and error counts.
+type ToolUsageEntry struct {
+	Name   string `json:"name"`   // tool name (e.g. "Bash") or skill name (e.g. "commit")
+	Uses   int    `json:"uses"`   // number of tool_use invocations
+	Errors int    `json:"errors"` // invocations whose tool_result reported an error
+}
+
+// ToolUsageResult is the tool/skill usage breakdown for a window/repo scope.
+// Tools are grouped by tool_name (excluding "Skill"); Skills are the "Skill"
+// tool's invocations grouped by the invoked skill name (tool_detail). Both
+// lists are ordered by Uses descending.
+type ToolUsageResult struct {
+	Tools  []ToolUsageEntry `json:"tools"`
+	Skills []ToolUsageEntry `json:"skills"`
+}
+
+// toolUsageLimit caps each list so a pathological history can't return thousands
+// of distinct tool/skill rows; the long tail is not useful in the breakdown.
+const toolUsageLimit = 50
+
+// ToolUsage returns the tool- and skill-invocation breakdown for sessions whose
+// start falls within the window (since; zero = lifetime) and optional repo.
+//
+// Invocations are counted from tool_use events. Errors are attributed by joining
+// each tool_use to its tool_result via tool_use_id/for_tool_use_id and counting
+// the ones flagged is_error — is_error lives on the result row, never on the
+// tool_use row, so the self-join is required. Scoping is by the OWNING session's
+// started_at/repo_id, matching AggregateStats/TrendData semantics.
+func (d *DB) ToolUsage(since time.Time, repoID string) (*ToolUsageResult, error) {
+	tools, err := d.toolUsageGrouped("u.tool_name", "u.tool_name != '' AND u.tool_name != 'Skill'", since, repoID)
+	if err != nil {
+		return nil, fmt.Errorf("ToolUsage tools: %w", err)
+	}
+	skills, err := d.toolUsageGrouped("u.tool_detail", "u.tool_name = 'Skill' AND COALESCE(u.tool_detail,'') != ''", since, repoID)
+	if err != nil {
+		return nil, fmt.Errorf("ToolUsage skills: %w", err)
+	}
+	return &ToolUsageResult{Tools: tools, Skills: skills}, nil
+}
+
+// toolUsageGrouped runs the shared tool/skill aggregation. keyCol is the GROUP BY
+// key (tool_name for tools, tool_detail for skills); rowFilter selects which
+// tool_use rows to include. since/repoID scope by the owning session.
+func (d *DB) toolUsageGrouped(keyCol, rowFilter string, since time.Time, repoID string) ([]ToolUsageEntry, error) {
+	conds := []string{rowFilter}
+	var args []interface{}
+	if !since.IsZero() {
+		// started_at is UTC RFC3339 (…Z); format the boundary in UTC so the
+		// lexical TEXT comparison is correct (see AggregateStats).
+		conds = append(conds, "s.started_at >= ?")
+		args = append(args, since.UTC().Format(time.RFC3339))
+	}
+	if repoID != "" {
+		conds = append(conds, "s.repo_id = ?")
+		args = append(args, repoID)
+	}
+	// COUNT(DISTINCT u.id): the LEFT JOIN can fan out a tool_use into several
+	// result rows, so dedupe by tool_use event id for both uses and errors.
+	q := `SELECT ` + keyCol + ` AS k,
+		COUNT(DISTINCT u.id) AS uses,
+		COUNT(DISTINCT CASE WHEN r.is_error = 1 THEN u.id END) AS errs
+		FROM events u
+		JOIN sessions s ON s.id = u.session_id
+		LEFT JOIN events r ON r.for_tool_use_id = u.tool_use_id AND r.session_id = u.session_id
+		WHERE ` + strings.Join(conds, " AND ") + `
+		GROUP BY k
+		ORDER BY uses DESC, k
+		LIMIT ?`
+	args = append(args, toolUsageLimit)
+
+	rows, err := d.db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make([]ToolUsageEntry, 0)
+	for rows.Next() {
+		var e ToolUsageEntry
+		if err := rows.Scan(&e.Name, &e.Uses, &e.Errors); err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+// SessionSkills returns, for every session that invoked at least one skill, the
+// skills it invoked with per-skill use/error counts. Skill invocations are
+// sparse, so the whole map is loaded in one query (no per-session round-trips);
+// History uses it to badge rows. Errors are attributed via the tool_use→
+// tool_result self-join (see ToolUsage).
+func (d *DB) SessionSkills() (map[string][]ToolUsageEntry, error) {
+	rows, err := d.db.Query(`SELECT u.session_id, u.tool_detail,
+		COUNT(DISTINCT u.id) AS uses,
+		COUNT(DISTINCT CASE WHEN r.is_error = 1 THEN u.id END) AS errs
+		FROM events u
+		LEFT JOIN events r ON r.for_tool_use_id = u.tool_use_id AND r.session_id = u.session_id
+		WHERE u.tool_name = 'Skill' AND COALESCE(u.tool_detail,'') != ''
+		GROUP BY u.session_id, u.tool_detail
+		ORDER BY u.session_id, uses DESC, u.tool_detail`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := make(map[string][]ToolUsageEntry)
+	for rows.Next() {
+		var sid string
+		var e ToolUsageEntry
+		if err := rows.Scan(&sid, &e.Name, &e.Uses, &e.Errors); err != nil {
+			return nil, err
+		}
+		out[sid] = append(out[sid], e)
+	}
+	return out, rows.Err()
+}
+
 // trendParams holds the parsed query parameters shared across TrendData helpers.
 //
 // windowWhere = all rows in window (used for cost/token SUMs, so each dollar is

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -884,12 +884,15 @@ func (d *DB) toolUsageGrouped(keyCol, rowFilter string, since time.Time, repoID 
 	}
 	// COUNT(DISTINCT u.id): the LEFT JOIN can fan out a tool_use into several
 	// result rows, so dedupe by tool_use event id for both uses and errors.
+	// The `u.tool_use_id != ''` guard is required: ids are stored as "" (never
+	// NULL) when absent, and without it an id-less tool_use would join to every
+	// id-less tool_result in the session and attribute phantom errors.
 	q := `SELECT ` + keyCol + ` AS k,
 		COUNT(DISTINCT u.id) AS uses,
 		COUNT(DISTINCT CASE WHEN r.is_error = 1 THEN u.id END) AS errs
 		FROM events u
 		JOIN sessions s ON s.id = u.session_id
-		LEFT JOIN events r ON r.for_tool_use_id = u.tool_use_id AND r.session_id = u.session_id
+		LEFT JOIN events r ON u.tool_use_id != '' AND r.for_tool_use_id = u.tool_use_id AND r.session_id = u.session_id
 		WHERE ` + strings.Join(conds, " AND ") + `
 		GROUP BY k
 		ORDER BY uses DESC, k
@@ -922,7 +925,7 @@ func (d *DB) SessionSkills() (map[string][]ToolUsageEntry, error) {
 		COUNT(DISTINCT u.id) AS uses,
 		COUNT(DISTINCT CASE WHEN r.is_error = 1 THEN u.id END) AS errs
 		FROM events u
-		LEFT JOIN events r ON r.for_tool_use_id = u.tool_use_id AND r.session_id = u.session_id
+		LEFT JOIN events r ON u.tool_use_id != '' AND r.for_tool_use_id = u.tool_use_id AND r.session_id = u.session_id
 		WHERE u.tool_name = 'Skill' AND COALESCE(u.tool_detail,'') != ''
 		GROUP BY u.session_id, u.tool_detail
 		ORDER BY u.session_id, uses DESC, u.tool_detail`)

--- a/internal/store/tool_usage_test.go
+++ b/internal/store/tool_usage_test.go
@@ -163,3 +163,45 @@ func TestToolUsageAndSessionSkills(t *testing.T) {
 		t.Errorf("map should be sparse — only sessions with skills present")
 	}
 }
+
+// TestToolUsage_EmptyToolUseIdNoPhantomErrors guards the self-join: a tool_use
+// with an empty tool_use_id must NOT join to empty-for_tool_use_id result rows
+// (ids are stored as "" not NULL), which would otherwise attribute phantom
+// errors. The use is still counted; only its error attribution is suppressed.
+func TestToolUsage_EmptyToolUseIdNoPhantomErrors(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	if _, err := db.db.Exec(`INSERT INTO sessions (id, started_at) VALUES ('se', '2026-05-31T12:00:00Z')`); err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	// A Bash tool_use with NO tool_use_id, and an error result with NO
+	// for_tool_use_id in the same session. The buggy join would match them.
+	if _, err := db.db.Exec(
+		`INSERT INTO events (session_id, message_id, role, tool_name, tool_use_id, timestamp)
+		 VALUES ('se','m1','assistant','Bash','','2026-05-31T12:00:01Z')`); err != nil {
+		t.Fatalf("seed tool_use: %v", err)
+	}
+	if _, err := db.db.Exec(
+		`INSERT INTO events (session_id, message_id, role, for_tool_use_id, is_error, timestamp)
+		 VALUES ('se','m2','user','',1,'2026-05-31T12:00:02Z')`); err != nil {
+		t.Fatalf("seed tool_result: %v", err)
+	}
+
+	res, err := db.ToolUsage(time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ToolUsage: %v", err)
+	}
+	var bash ToolUsageEntry
+	for _, e := range res.Tools {
+		if e.Name == "Bash" {
+			bash = e
+		}
+	}
+	if bash.Uses != 1 {
+		t.Errorf("Bash uses = %d, want 1 (the id-less tool_use is still counted)", bash.Uses)
+	}
+	if bash.Errors != 0 {
+		t.Errorf("Bash errors = %d, want 0 (empty tool_use_id must not match the empty-id error result)", bash.Errors)
+	}
+}

--- a/internal/store/tool_usage_test.go
+++ b/internal/store/tool_usage_test.go
@@ -1,0 +1,165 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/zxela/claude-monitor/internal/repo"
+)
+
+// TestToolUsageAndSessionSkills exercises the tool/skill aggregation: invocation
+// counts, error attribution via the tool_use→tool_result self-join, the
+// tools-vs-skills split, and window/repo scoping, plus the sparse per-session
+// skills map used by History.
+func TestToolUsageAndSessionSkills(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	// Repos (sessions.repo_id references repos).
+	for _, id := range []string{"repoA", "repoB"} {
+		if err := db.UpsertRepo(&repo.Repo{ID: id, Name: id}); err != nil {
+			t.Fatalf("UpsertRepo %s: %v", id, err)
+		}
+	}
+	// s1: recent, repoA. s2: older, repoB.
+	mkSession := func(id, repoID, started string) {
+		t.Helper()
+		if _, err := db.db.Exec(`INSERT INTO sessions (id, repo_id, started_at) VALUES (?,?,?)`, id, repoID, started); err != nil {
+			t.Fatalf("seed session %s: %v", id, err)
+		}
+	}
+	mkSession("s1", "repoA", "2026-05-31T12:00:00Z")
+	mkSession("s2", "repoB", "2026-05-20T12:00:00Z")
+
+	var seq int
+	use := func(session, tool, detail, tuid string) {
+		t.Helper()
+		seq++
+		if _, err := db.db.Exec(
+			`INSERT INTO events (session_id, message_id, role, tool_name, tool_detail, tool_use_id, timestamp)
+			 VALUES (?,?,?,?,?,?,?)`,
+			session, fmt.Sprintf("m%d", seq), "assistant", tool, detail, tuid, "2026-05-31T12:00:01Z",
+		); err != nil {
+			t.Fatalf("seed tool_use: %v", err)
+		}
+	}
+	result := func(session, forTUID string, isErr int) {
+		t.Helper()
+		seq++
+		if _, err := db.db.Exec(
+			`INSERT INTO events (session_id, message_id, role, for_tool_use_id, is_error, timestamp)
+			 VALUES (?,?,?,?,?,?)`,
+			session, fmt.Sprintf("m%d", seq), "user", forTUID, isErr, "2026-05-31T12:00:02Z",
+		); err != nil {
+			t.Fatalf("seed tool_result: %v", err)
+		}
+	}
+
+	// s1: Bash ok, Bash error, Skill commit ok, Skill commit error, Skill review-pr (no result row).
+	use("s1", "Bash", "ls", "tu1")
+	result("s1", "tu1", 0)
+	use("s1", "Bash", "bad", "tu2")
+	result("s1", "tu2", 1)
+	use("s1", "Skill", "commit", "tu3")
+	result("s1", "tu3", 0)
+	use("s1", "Skill", "commit", "tu4")
+	result("s1", "tu4", 1)
+	use("s1", "Skill", "review-pr", "tu5") // no result → uses=1, errors=0
+	// s2 (older, repoB): Read ok, Skill deploy ok.
+	use("s2", "Read", "f.go", "tu6")
+	result("s2", "tu6", 0)
+	use("s2", "Skill", "deploy", "tu7")
+	result("s2", "tu7", 0)
+
+	find := func(list []ToolUsageEntry, name string) ToolUsageEntry {
+		for _, e := range list {
+			if e.Name == name {
+				return e
+			}
+		}
+		return ToolUsageEntry{Name: "<missing:" + name + ">"}
+	}
+
+	// --- Lifetime, all repos ---
+	all, err := db.ToolUsage(time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ToolUsage all: %v", err)
+	}
+	if got := find(all.Tools, "Bash"); got.Uses != 2 || got.Errors != 1 {
+		t.Errorf("Bash = %+v, want uses=2 errors=1", got)
+	}
+	if got := find(all.Tools, "Read"); got.Uses != 1 || got.Errors != 0 {
+		t.Errorf("Read = %+v, want uses=1 errors=0", got)
+	}
+	for _, e := range all.Tools {
+		if e.Name == "Skill" {
+			t.Errorf("Tools must exclude the Skill tool, got %+v", e)
+		}
+	}
+	if got := find(all.Skills, "commit"); got.Uses != 2 || got.Errors != 1 {
+		t.Errorf("commit skill = %+v, want uses=2 errors=1", got)
+	}
+	if got := find(all.Skills, "review-pr"); got.Uses != 1 || got.Errors != 0 {
+		t.Errorf("review-pr skill = %+v, want uses=1 errors=0", got)
+	}
+	if got := find(all.Skills, "deploy"); got.Uses != 1 {
+		t.Errorf("deploy skill = %+v, want uses=1", got)
+	}
+	// Ordering: most-used first.
+	if len(all.Tools) >= 2 && all.Tools[0].Name != "Bash" {
+		t.Errorf("Tools[0] = %q, want Bash (most-used first)", all.Tools[0].Name)
+	}
+	if len(all.Skills) >= 1 && all.Skills[0].Name != "commit" {
+		t.Errorf("Skills[0] = %q, want commit (most-used first)", all.Skills[0].Name)
+	}
+
+	// --- Repo scope: repoA only ---
+	a, err := db.ToolUsage(time.Time{}, "repoA")
+	if err != nil {
+		t.Fatalf("ToolUsage repoA: %v", err)
+	}
+	if got := find(a.Tools, "Read"); got.Uses != 0 {
+		t.Errorf("repoA must exclude Read (it's in repoB), got %+v", got)
+	}
+	if got := find(a.Skills, "deploy"); got.Uses != 0 {
+		t.Errorf("repoA must exclude deploy skill (repoB), got %+v", got)
+	}
+	if got := find(a.Skills, "commit"); got.Uses != 2 {
+		t.Errorf("repoA commit = %+v, want uses=2", got)
+	}
+
+	// --- Window scope: since 2026-05-25 excludes the older s2 ---
+	since, _ := time.Parse(time.RFC3339, "2026-05-25T00:00:00Z")
+	win, err := db.ToolUsage(since, "")
+	if err != nil {
+		t.Fatalf("ToolUsage window: %v", err)
+	}
+	if got := find(win.Tools, "Read"); got.Uses != 0 {
+		t.Errorf("window must exclude Read from older s2, got %+v", got)
+	}
+	if got := find(win.Skills, "deploy"); got.Uses != 0 {
+		t.Errorf("window must exclude deploy from older s2, got %+v", got)
+	}
+	if got := find(win.Tools, "Bash"); got.Uses != 2 {
+		t.Errorf("window Bash = %+v, want uses=2 (s1 in window)", got)
+	}
+
+	// --- Per-session skills map (sparse) ---
+	m, err := db.SessionSkills()
+	if err != nil {
+		t.Fatalf("SessionSkills: %v", err)
+	}
+	if len(m["s1"]) != 2 {
+		t.Errorf("s1 skills = %+v, want 2 (commit, review-pr)", m["s1"])
+	}
+	if got := find(m["s1"], "commit"); got.Uses != 2 || got.Errors != 1 {
+		t.Errorf("s1 commit = %+v, want uses=2 errors=1", got)
+	}
+	if len(m["s2"]) != 1 || m["s2"][0].Name != "deploy" {
+		t.Errorf("s2 skills = %+v, want [deploy]", m["s2"])
+	}
+	if _, ok := m["no-such-session"]; ok {
+		t.Errorf("map should be sparse — only sessions with skills present")
+	}
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -6,6 +6,8 @@ import type {
   StorageInfo,
   RepoEntry,
   TrendResult,
+  ToolUsage,
+  SessionSkills,
 } from './types';
 
 async function request<T>(url: string): Promise<T> {
@@ -77,6 +79,16 @@ export async function fetchTrends(window: TrendWindow = '7d', repo?: string): Pr
   const params = new URLSearchParams({ window });
   if (repo) params.set('repo', repo);
   return request<TrendResult>(`/api/stats/trends?${params}`);
+}
+
+export async function fetchToolUsage(window: TrendWindow = '7d', repo?: string): Promise<ToolUsage> {
+  const params = new URLSearchParams({ window });
+  if (repo) params.set('repo', repo);
+  return request<ToolUsage>(`/api/stats/tools?${params}`);
+}
+
+export async function fetchSessionSkills(): Promise<SessionSkills> {
+  return request<SessionSkills>(`/api/skills/sessions`);
 }
 
 export async function fetchVersion(): Promise<string> {

--- a/web/src/components/analytics-cards.ts
+++ b/web/src/components/analytics-cards.ts
@@ -1,6 +1,6 @@
 import { Chart, COLORS, DARK_THEME } from '../chart-config';
-import { formatTokens } from '../utils';
-import type { TrendResult } from '../types';
+import { formatTokens, escapeHtml } from '../utils';
+import type { TrendResult, ToolUsage, ToolUsageEntry } from '../types';
 
 type CardState = Record<string, boolean>;
 type OnToggle = (cardId: string, expanded: boolean) => void;
@@ -418,4 +418,112 @@ export function destroyCards(): void {
     chart.destroy();
   }
   charts.clear();
+}
+
+// SKILL_COLOR matches the feed's skill accent so the surfaces feel related.
+const SKILL_COLOR = '#e879f9';
+const TOOL_COLOR = COLORS.yellow;
+
+/** Render the (non-chart) "Tool & Skill Usage" card: two ranked lists of
+ *  invocation counts with error counts, skills broken out separately. Appended
+ *  after the chart cards by analytics-view; manages its own collapse toggle. */
+export function renderToolUsageCard(
+  container: HTMLElement,
+  usage: ToolUsage | null,
+  expanded: boolean,
+  onToggle: (expanded: boolean) => void,
+): void {
+  const card = document.createElement('div');
+  card.className = 'analytics-card';
+  card.dataset.cardId = 'tool-skill-usage';
+
+  const header = document.createElement('div');
+  header.className = 'analytics-card-header';
+  header.setAttribute('role', 'button');
+  header.setAttribute('tabindex', '0');
+  header.setAttribute('aria-expanded', String(expanded));
+  header.innerHTML = `
+    <span class="analytics-card-toggle">${expanded ? '▼' : '▶'}</span>
+    <span class="analytics-card-title">Tool &amp; Skill Usage</span>
+    <span class="analytics-card-subtitle">invocations &amp; errors</span>
+  `;
+
+  const body = document.createElement('div');
+  body.className = 'analytics-card-body';
+  body.style.display = expanded ? '' : 'none';
+  body.appendChild(buildToolUsageBody(usage));
+
+  card.appendChild(header);
+  card.appendChild(body);
+  container.appendChild(card);
+
+  header.addEventListener('click', () => {
+    const isExpanded = body.style.display !== 'none';
+    body.style.display = isExpanded ? 'none' : '';
+    header.querySelector('.analytics-card-toggle')!.textContent = isExpanded ? '▶' : '▼';
+    header.setAttribute('aria-expanded', String(!isExpanded));
+    onToggle(!isExpanded);
+  });
+  header.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      header.click();
+    }
+  });
+}
+
+function buildToolUsageBody(usage: ToolUsage | null): HTMLElement {
+  const wrap = document.createElement('div');
+  wrap.className = 'tool-usage';
+  const skills = usage?.skills ?? [];
+  const tools = usage?.tools ?? [];
+  if (skills.length === 0 && tools.length === 0) {
+    wrap.innerHTML = '<div class="analytics-empty">No tool or skill activity in this period</div>';
+    return wrap;
+  }
+  wrap.appendChild(buildUsageSection('Skills', skills, SKILL_COLOR, 'No skills invoked'));
+  wrap.appendChild(buildUsageSection('Tools', tools, TOOL_COLOR, 'No tools used'));
+  return wrap;
+}
+
+function buildUsageSection(
+  title: string,
+  entries: ToolUsageEntry[],
+  color: string,
+  emptyText: string,
+): HTMLElement {
+  const section = document.createElement('div');
+  section.className = 'tool-usage-section';
+
+  const heading = document.createElement('div');
+  heading.className = 'tool-usage-section-title';
+  heading.textContent = `${title} (${entries.length})`;
+  section.appendChild(heading);
+
+  if (entries.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'tool-usage-empty';
+    empty.textContent = emptyText;
+    section.appendChild(empty);
+    return section;
+  }
+
+  const max = Math.max(...entries.map((e) => e.uses), 1);
+  for (const e of entries) {
+    const row = document.createElement('div');
+    row.className = 'tool-usage-row';
+    // Floor at 2% so a 1-use bar is still visible.
+    const pct = Math.max(2, Math.round((e.uses / max) * 100));
+    const errBadge =
+      e.errors > 0
+        ? `<span class="tool-usage-err" title="${e.errors} invocation(s) errored">${e.errors} err</span>`
+        : '';
+    row.innerHTML =
+      `<span class="tool-usage-name" title="${escapeHtml(e.name)}">${escapeHtml(e.name)}</span>` +
+      `<span class="tool-usage-bar-wrap"><span class="tool-usage-bar" style="width:${pct}%;background:${color}"></span></span>` +
+      `<span class="tool-usage-count">${e.uses}</span>` +
+      errBadge;
+    section.appendChild(row);
+  }
+  return section;
 }

--- a/web/src/components/analytics-view.ts
+++ b/web/src/components/analytics-view.ts
@@ -1,10 +1,10 @@
 import type { AppState } from '../state';
-import type { TrendResult, RepoEntry } from '../types';
+import type { TrendResult, RepoEntry, ToolUsage } from '../types';
 import type { TrendWindow } from '../api';
 import { state, subscribe } from '../state';
-import { fetchTrends, fetchRepos } from '../api';
+import { fetchTrends, fetchRepos, fetchToolUsage } from '../api';
 import { formatTokens } from '../utils';
-import { renderCards, destroyCards } from './analytics-cards';
+import { renderCards, renderToolUsageCard, destroyCards } from './analytics-cards';
 import '../styles/analytics.css';
 
 let container: HTMLElement | null = null;
@@ -14,6 +14,7 @@ let currentWindow: TrendWindow =
 let currentRepo: string | undefined;
 let repos: RepoEntry[] = [];
 let trendData: TrendResult | null = null;
+let toolUsage: ToolUsage | null = null;
 let loaded = false;
 let loading = false;
 
@@ -140,6 +141,13 @@ function show(): void {
       renderCards(cardsContainer, trendData, getCardState(), (id, expanded) => {
         setCardState(id, expanded);
       });
+      // Tool & Skill Usage is a non-chart card appended after the chart cards;
+      // renderCards clears the container, so it must be (re)added here each render.
+      const cs = getCardState();
+      const tuExpanded = cs['tool-skill-usage'] !== undefined ? cs['tool-skill-usage'] : true;
+      renderToolUsageCard(cardsContainer, toolUsage, tuExpanded, (expanded) => {
+        setCardState('tool-skill-usage', expanded);
+      });
     }
   }
 
@@ -164,11 +172,13 @@ async function loadData(): Promise<void> {
   }
 
   try {
-    const [trends, repoList] = await Promise.all([
+    const [trends, usage, repoList] = await Promise.all([
       fetchTrends(currentWindow, currentRepo),
+      fetchToolUsage(currentWindow, currentRepo),
       loaded ? Promise.resolve(repos) : fetchRepos(),
     ]);
     trendData = trends;
+    toolUsage = usage;
     repos = repoList;
     loaded = true;
   } catch (err) {

--- a/web/src/components/feed-panel.ts
+++ b/web/src/components/feed-panel.ts
@@ -35,6 +35,7 @@ const FILTER_TYPES = [
   'assistant',
   'tool_use',
   'tool_result',
+  'skill',
   'agent',
   'command',
   'hook',

--- a/web/src/components/history-view.ts
+++ b/web/src/components/history-view.ts
@@ -1,8 +1,8 @@
 // web/src/components/history-view.ts
-import type { Session } from '../types';
+import type { Session, SessionSkills } from '../types';
 import type { AppState } from '../state';
 import { state, subscribe, update } from '../state';
-import { fetchSessions } from '../api';
+import { fetchSessions, fetchSessionSkills } from '../api';
 import { formatDurationSecs, formatTokens, effectiveInputTokens } from '../utils';
 import '../styles/views.css';
 
@@ -37,6 +37,11 @@ const seenIds = new Set<string>();
 // Populated by groupRows() and consumed by the Cost column + its sort so the
 // most expensive session trees rank correctly and match the same-row badge.
 const treeCostMap = new Map<string, number>();
+
+// Sparse map of sessionID → skills invoked, loaded once. Used to badge the rows
+// whose sessions invoked skills so they stand out in History.
+let sessionSkills: SessionSkills = {};
+let skillsLoaded = false;
 
 type Column = { key: string; label: string; cls?: string; fmt: (r: Session) => string };
 
@@ -146,6 +151,19 @@ async function loadData(append = false): Promise<void> {
     reachedEnd = false;
     seenIds.clear();
     data = [];
+  }
+  // Load the sparse session→skills map once (fire-and-forget): it's small and
+  // all-time, so it badges rows across every page. Re-render when it arrives.
+  if (!append && !skillsLoaded) {
+    skillsLoaded = true;
+    fetchSessionSkills()
+      .then((m) => {
+        sessionSkills = m;
+        if (state.view === 'history') show();
+      })
+      .catch(() => {
+        /* non-fatal: rows simply render without skill badges */
+      });
   }
   try {
     const raw = await fetchSessions(PAGE, offset);
@@ -489,6 +507,21 @@ function createRow(row: Session, isChild: boolean): HTMLTableRowElement {
     if (col.key === 'session') td.title = row.taskDescription || '';
     if (col.key === 'project') td.title = row.repoId || row.cwd || '';
     tr.appendChild(td);
+  }
+
+  // Skill badge: this session invoked one or more skills — surface it so skill
+  // runs are discoverable from History (they are otherwise buried in the feed).
+  const skills = sessionSkills[row.id];
+  if (skills && skills.length > 0) {
+    const total = skills.reduce((sum, s) => sum + s.uses, 0);
+    const nameCell = tr.children[1] as HTMLElement;
+    const badge = document.createElement('span');
+    badge.className = 'history-skill-badge';
+    badge.textContent = `✦ ${total}`;
+    badge.title =
+      'Skills invoked:\n' +
+      skills.map((s) => `${s.name} ×${s.uses}${s.errors ? ` (${s.errors} err)` : ''}`).join('\n');
+    nameCell.appendChild(badge);
   }
   tr.setAttribute('tabindex', '0');
   tr.setAttribute('role', 'button');

--- a/web/src/components/history-view.ts
+++ b/web/src/components/history-view.ts
@@ -1,5 +1,5 @@
 // web/src/components/history-view.ts
-import type { Session, SessionSkills } from '../types';
+import type { Session, SessionSkills, ToolUsageEntry } from '../types';
 import type { AppState } from '../state';
 import { state, subscribe, update } from '../state';
 import { fetchSessions, fetchSessionSkills } from '../api';
@@ -437,6 +437,14 @@ function show(): void {
         nameCell.title = titleLines.join('\n');
       }
     }
+
+    // Skill badge rolls up own + subagent-tree skills (mirrors the Cost column)
+    // so a COLLAPSED parent still surfaces skills its children invoked — they'd
+    // otherwise vanish with the hidden child rows.
+    addSkillBadge(
+      tr.children[1] as HTMLElement,
+      mergeSkills([sessionSkills[parent.id] ?? [], ...children.map((c) => sessionSkills[c.id] ?? [])]),
+    );
     tbody.appendChild(tr);
 
     // Child rows (if not collapsed)
@@ -456,6 +464,7 @@ function show(): void {
       }
       for (const child of children) {
         const childTr = createRow(child, true);
+        addSkillBadge(childTr.children[1] as HTMLElement, sessionSkills[child.id] ?? []);
         tbody.appendChild(childTr);
       }
     }
@@ -496,6 +505,40 @@ function show(): void {
   container.appendChild(wrapper);
 }
 
+// mergeSkills combines several per-session skill lists into one, summing uses
+// and errors per skill name, ordered by uses descending. Used to roll a parent's
+// subagent-tree skills into its row badge.
+function mergeSkills(lists: ToolUsageEntry[][]): ToolUsageEntry[] {
+  const byName = new Map<string, ToolUsageEntry>();
+  for (const list of lists) {
+    for (const s of list) {
+      const cur = byName.get(s.name);
+      if (cur) {
+        cur.uses += s.uses;
+        cur.errors += s.errors;
+      } else {
+        byName.set(s.name, { name: s.name, uses: s.uses, errors: s.errors });
+      }
+    }
+  }
+  return [...byName.values()].sort((a, b) => b.uses - a.uses || a.name.localeCompare(b.name));
+}
+
+// addSkillBadge appends a fuchsia "✦ N" badge to a row's Session cell when the
+// row (or its subagent tree, for a parent) invoked skills, so skill activity is
+// discoverable from History instead of being buried in the feed.
+function addSkillBadge(nameCell: HTMLElement, skills: ToolUsageEntry[]): void {
+  if (skills.length === 0) return;
+  const total = skills.reduce((sum, s) => sum + s.uses, 0);
+  const badge = document.createElement('span');
+  badge.className = 'history-skill-badge';
+  badge.textContent = `✦ ${total}`;
+  badge.title =
+    'Skills invoked:\n' +
+    skills.map((s) => `${s.name} ×${s.uses}${s.errors ? ` (${s.errors} err)` : ''}`).join('\n');
+  nameCell.appendChild(badge);
+}
+
 function createRow(row: Session, isChild: boolean): HTMLTableRowElement {
   const tr = document.createElement('tr');
   if (isChild) tr.className = 'history-child-row';
@@ -507,21 +550,6 @@ function createRow(row: Session, isChild: boolean): HTMLTableRowElement {
     if (col.key === 'session') td.title = row.taskDescription || '';
     if (col.key === 'project') td.title = row.repoId || row.cwd || '';
     tr.appendChild(td);
-  }
-
-  // Skill badge: this session invoked one or more skills — surface it so skill
-  // runs are discoverable from History (they are otherwise buried in the feed).
-  const skills = sessionSkills[row.id];
-  if (skills && skills.length > 0) {
-    const total = skills.reduce((sum, s) => sum + s.uses, 0);
-    const nameCell = tr.children[1] as HTMLElement;
-    const badge = document.createElement('span');
-    badge.className = 'history-skill-badge';
-    badge.textContent = `✦ ${total}`;
-    badge.title =
-      'Skills invoked:\n' +
-      skills.map((s) => `${s.name} ×${s.uses}${s.errors ? ` (${s.errors} err)` : ''}`).join('\n');
-    nameCell.appendChild(badge);
   }
   tr.setAttribute('tabindex', '0');
   tr.setAttribute('role', 'button');

--- a/web/src/components/render-message.test.ts
+++ b/web/src/components/render-message.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { detectType, renderFeedEntry } from './render-message';
+import type { Event } from '../types';
+
+// Minimal Event factory — only the fields detectType/renderFeedEntry inspect.
+function makeEvent(over: Partial<Event>): Event {
+  return {
+    id: 1,
+    sessionId: 's',
+    type: 'message',
+    role: 'assistant',
+    contentPreview: '',
+    costUSD: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    isError: false,
+    timestamp: '2024-01-01T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('skill invocation rendering', () => {
+  it('classifies a Skill tool_use as its own type (not a generic tool_use)', () => {
+    const ev = makeEvent({
+      role: 'assistant',
+      toolName: 'Skill',
+      toolDetail: 'commit-commands:commit',
+    });
+    expect(detectType(ev)).toBe('skill');
+  });
+
+  it('does NOT classify ordinary tools as skill', () => {
+    expect(detectType(makeEvent({ role: 'assistant', toolName: 'Bash' }))).toBe('tool_use');
+    expect(detectType(makeEvent({ role: 'assistant', toolName: 'Read' }))).toBe('tool_use');
+  });
+
+  it('falls back to the [skill:] preview when toolName is missing (streaming race)', () => {
+    const ev = makeEvent({
+      role: 'assistant',
+      toolName: '',
+      contentPreview: '[skill: triage-issue]',
+    });
+    expect(detectType(ev)).toBe('skill');
+  });
+
+  it('renders the skill name with the distinct skill content class and chip', () => {
+    const ev = makeEvent({ role: 'assistant', toolName: 'Skill', toolDetail: 'review-pr' });
+    const el = renderFeedEntry(ev);
+    expect(el.classList.contains('type-skill')).toBe(true);
+    const chip = el.querySelector('.fe-type');
+    expect(chip?.textContent).toBe('[skill]');
+    const content = el.querySelector('.fe-content');
+    expect(content?.classList.contains('skill')).toBe(true);
+    expect(content?.textContent).toContain('review-pr');
+  });
+});

--- a/web/src/components/render-message.ts
+++ b/web/src/components/render-message.ts
@@ -10,6 +10,7 @@ type MessageType =
   | 'user'
   | 'assistant'
   | 'tool_use'
+  | 'skill'
   | 'tool_result'
   | 'agent'
   | 'hook'
@@ -48,10 +49,16 @@ export function detectType(msg: Event): MessageType {
     return 'command';
   // Agent tool calls show as 'agent' type, not 'tool_use'
   if (msg.isAgent && msg.role === 'assistant') return 'agent';
+  // Skill invocations get their own type so they stand out from ordinary tool
+  // calls — a skill otherwise renders identically to a Bash/Read line and is
+  // easy to miss (its only other signal is the user turn that follows it).
+  if (msg.toolName === 'Skill' && msg.role === 'assistant') return 'skill';
   if (msg.toolName && msg.role === 'assistant') return 'tool_use';
-  // Fallback: detect agent/tool_use from content preview when fields weren't persisted (streaming race)
+  // Fallback: detect agent/skill/tool_use from content preview when fields weren't persisted (streaming race)
   if (!msg.toolName && msg.role === 'assistant' && msg.contentPreview?.startsWith('[agent'))
     return 'agent';
+  if (!msg.toolName && msg.role === 'assistant' && msg.contentPreview?.startsWith('[skill:'))
+    return 'skill';
   if (!msg.toolName && msg.role === 'assistant' && msg.contentPreview?.startsWith('[tool: '))
     return 'tool_use';
   if (msg.forToolUseId) return 'tool_result';
@@ -132,6 +139,18 @@ export function renderFeedEntry(msg: Event, opts: RenderOptions = {}): HTMLEleme
     content = display ? `Agent: ${truncate(display, 80)}` : 'Agent';
     contentClass = 'tool';
     fullContent = rawText || detail;
+  } else if (type === 'skill') {
+    // High-signal: surface the skill name prominently. toolDetail holds the skill
+    // name; fall back to parsing the "[skill: x]" preview (streaming race).
+    let skillName = detail;
+    if (!skillName) {
+      const m = rawText.match(/^\[skill:\s*([^\]]+)\]/);
+      if (m) skillName = m[1].trim();
+    }
+    content = skillName ? `✦ ${skillName}` : '✦ skill';
+    contentClass = 'skill';
+    // Expand reveals the full Skill tool input (skill name + args).
+    fullContent = formatToolExpand('Skill', fullText) || detail || rawText;
   } else if (type === 'tool_use') {
     // Extract tool name from content preview if toolName field is missing (streaming race)
     let name = msg.toolName || '';

--- a/web/src/state.ts
+++ b/web/src/state.ts
@@ -78,6 +78,7 @@ export const state: AppState = {
     assistant: true,
     tool_use: true,
     tool_result: true,
+    skill: true,
     agent: true,
     hook: true,
     error: true,

--- a/web/src/styles/analytics.css
+++ b/web/src/styles/analytics.css
@@ -148,3 +148,78 @@
 .analytics-card-body canvas {
   width: 100% !important;
 }
+
+/* Tool & Skill Usage card — two ranked lists of invocation/error counts. */
+.tool-usage {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.tool-usage-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.tool-usage-section-title {
+  font-family: monospace;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--text-secondary, #888);
+  margin-bottom: 2px;
+}
+.tool-usage-empty {
+  font-family: monospace;
+  font-size: 12px;
+  color: var(--text-secondary, #666);
+  padding: 2px 0;
+}
+.tool-usage-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: monospace;
+  font-size: 12px;
+}
+.tool-usage-name {
+  flex: 0 0 200px;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary, #e0e0e0);
+}
+.tool-usage-bar-wrap {
+  flex: 1;
+  min-width: 0;
+  height: 10px;
+  background: var(--bg-secondary, #1e1e3a);
+  border-radius: 5px;
+  overflow: hidden;
+}
+.tool-usage-bar {
+  display: block;
+  height: 100%;
+  border-radius: 5px;
+  min-width: 2px;
+}
+.tool-usage-count {
+  flex: 0 0 auto;
+  min-width: 42px;
+  text-align: right;
+  color: var(--text-primary, #e0e0e0);
+}
+.tool-usage-err {
+  flex: 0 0 auto;
+  color: #ff6b6b;
+  font-size: 11px;
+  min-width: 48px;
+  text-align: right;
+}
+
+@media (max-width: 600px) {
+  .tool-usage-name {
+    flex-basis: 120px;
+    max-width: 120px;
+  }
+}

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -395,6 +395,20 @@ body {
   font-style: italic;
 }
 
+/* Skill badge — fuchsia to match the feed's skill accent, so sessions that
+   invoked skills are spottable at a glance in History. */
+.history-skill-badge {
+  font-size: 10px;
+  color: #e879f9;
+  background: rgba(232, 121, 249, 0.12);
+  border: 1px solid rgba(232, 121, 249, 0.35);
+  border-radius: 3px;
+  padding: 0 5px;
+  margin-left: 8px;
+  white-space: nowrap;
+  cursor: help;
+}
+
 .history-workflow-band {
   background: var(--bg-hover, rgba(255, 255, 255, 0.02));
 }

--- a/web/src/styles/feed.css
+++ b/web/src/styles/feed.css
@@ -251,6 +251,14 @@
   background: rgba(168, 85, 247, 0.03);
 }
 
+/* Skills — highest-signal: a bold fuchsia identity with a stronger border and
+   tint so a skill invocation is unmistakable in the stream (it otherwise looks
+   like any other tool call). */
+.feed-entry.type-skill {
+  border-left-color: rgba(232, 121, 249, 0.7);
+  background: rgba(232, 121, 249, 0.07);
+}
+
 /* Low signal — tool output (readable but recessed) */
 .feed-entry.type-tool_result {
   border-left-color: rgba(0, 204, 255, 0.15);
@@ -299,6 +307,9 @@
 .fe-type.tool_use {
   color: var(--color-tool-use);
 }
+.fe-type.skill {
+  color: #e879f9;
+}
 .fe-type.agent {
   color: var(--color-agent);
 }
@@ -333,6 +344,10 @@
 }
 .fe-content.tool {
   color: var(--yellow);
+}
+.fe-content.skill {
+  color: #e879f9;
+  font-weight: 600;
 }
 .fe-content.result {
   color: var(--color-result);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -194,3 +194,19 @@ export interface RepoEntry {
   url?: string;
   totalCost: number;
 }
+
+/** One tool or skill with its invocation and error counts. */
+export interface ToolUsageEntry {
+  name: string; // tool name (e.g. "Bash") or skill name (e.g. "commit")
+  uses: number; // number of invocations
+  errors: number; // invocations whose result reported an error
+}
+
+/** Tool/skill usage breakdown for a window/repo scope (GET /api/stats/tools). */
+export interface ToolUsage {
+  tools: ToolUsageEntry[];
+  skills: ToolUsageEntry[];
+}
+
+/** Sparse map of sessionID → skills invoked (GET /api/skills/sessions). */
+export type SessionSkills = Record<string, ToolUsageEntry[]>;


### PR DESCRIPTION
## Why

Skill invocations were **captured** (`events.tool_name='Skill'`, `tool_detail=<skill>`) but never **surfaced**. In the feed a skill rendered identically to any other tool call — its only signal was a `Skill` tool line followed by a user turn, which is easy to miss — and no analytics or history view exposed tool/skill usage at all. The product already has a "Cost by Model / Repo / Session" analytics family; "by Tool / Skill" was the missing member.

## What

**Feed / replay legibility (the headline fix)**
- New `skill` message type in `render-message.ts`: a skill now renders as a distinct **fuchsia row** — `✦ <skill>`, a `[skill]` chip, a left border + background tint — instead of a plain `[tool_use]` line, so it's unmistakable in the stream (both the live feed and replay reuse `renderFeedEntry`).
- Added a **SKILL** feed-filter chip (defaults on) to isolate skill events.

**Backend aggregation + API**
- `store.ToolUsage(since, repoID)` → tool- and skill-invocation counts **with error counts**, grouped by `tool_name` (tools) and `tool_detail` (skills). Errors are attributed via a `tool_use`→`tool_result` self-join because `is_error` lives on the result row, never the `tool_use` row. Scoped by the owning session's `started_at`/`repo_id`, matching `AggregateStats`/`TrendData`.
- `store.SessionSkills()` → sparse `sessionID → skills` map (skills are rare, so one cheap query badges every History page).
- New endpoints: `GET /api/stats/tools?window=&repo=` and `GET /api/skills/sessions`.

**Analytics**
- New **"Tool & Skill Usage"** card: ranked `uses + errors` bars, skills broken out separately above tools, window/repo-scoped like the rest of the view.

**History**
- Per-row fuchsia **`✦ N`** skill badge (tooltip lists each skill ×uses / errors) so sessions that invoked skills stand out.

## Metric choice
Counts + error counts only — **no per-tool cost**. Cost in the JSONL lands on the assistant *turn* and the parser keys one event to the turn's last tool, so "cost by tool" would be misleading; counts are honest. (Same reason the existing "Cost by Repo" is labelled *approximate*.)

## Tests / verification
- Go: `TestToolUsageAndSessionSkills` — counts, error self-join, tools/skills split, window + repo scoping, sparse map.
- Frontend: `render-message.test.ts` — skill classification (incl. the `[skill:]` streaming-race fallback) and the distinct render (chip/class).
- `go test ./...` green (11 pkgs); frontend `tsc`/`typecheck:test`/`lint` (0 errors)/`vitest` (43)/`vite build` all pass.
- Verified end-to-end against a **copy** of the live DB (separate port/HOME, no disturbance to the running service): `/api/stats/tools` returned Bash 8373 uses / 161 err, Read 1713/13, skills incl. `review-pr` 5/5 and `commit-push-pr` 3/1; 17 sessions badged in History; the fuchsia skill row renders in the feed and the card renders in Analytics (screenshotted via Playwright).

## Notes
- `cmd/claude-monitor/static/` is gitignored and built in CI (`npm run build`), so no built assets are committed.
- Independent of #236 (repo-attribution follow-ups) — branched from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)