### PR TITLE
fix: clear low/nit follow-ups from the workflow-logging audit (#222)

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -185,6 +185,17 @@ func (p *Pipeline) Process(ev watcher.Event) {
 					// Fall back to the (possibly stale) stored error_count only if
 					// the deterministic recount failed.
 					s.ErrorCount = dbSess.ErrorCount
+					// Restore the identity columns too. The main Upsert below re-stamps
+					// these from the watcher event (set-once), so they are usually
+					// re-derived on this same event — but a first post-restart line that
+					// carries no parent signal (e.g. a lone summary line) would otherwise
+					// broadcast the subagent with an empty ParentID until a later
+					// sidechain line arrives. Copying from the DB row keeps the
+					// in-memory session consistent with persisted state immediately.
+					s.ParentID = dbSess.ParentID
+					s.WorkflowID = dbSess.WorkflowID
+					s.AgentID = dbSess.AgentID
+					s.AgentKind = dbSess.AgentKind
 				}
 				if errCountErr == nil {
 					s.ErrorCount = errCount
@@ -553,10 +564,14 @@ func (p *Pipeline) resolveParentID(msg *parser.Event, ev watcher.Event) string {
 		if sid := parentSessionIDFromPath(ev.FilePath); sid != "" && sid != ev.SessionID {
 			return sid
 		}
-		// Neither source found a parent — record a deferred link.
+		// Neither source found a parent — record a deferred link. Guard on !ok so
+		// this matches the in-content sibling's set-once policy above and never
+		// overwrites an already-recorded pending link for this child.
 		if msg.ParentUUID != "" && msg.ParentUUID != ev.SessionID {
 			p.linkMu.Lock()
-			p.pendingParentLinks[ev.SessionID] = msg.ParentUUID
+			if _, ok := p.pendingParentLinks[ev.SessionID]; !ok {
+				p.pendingParentLinks[ev.SessionID] = msg.ParentUUID
+			}
 			p.linkMu.Unlock()
 		}
 		return ""

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -166,6 +166,14 @@ func TestParentSessionIDFromPath(t *testing.T) {
 		{"/home/user/.claude/projects/hash/abc-123/subagents/workflows/wf_def/agent-xyz.jsonl", "abc-123"},
 		{"/home/user/.claude/projects/hash/session.jsonl", ""},
 		{"/tmp/test.jsonl", ""},
+		// Nested subagents: the walk returns the FIRST (innermost) "subagents"
+		// parent going up, so a subagent-of-a-subagent attributes to its immediate
+		// agent parent, not the top-level session.
+		{"/home/u/.claude/projects/hash/gp/subagents/agent-x/subagents/agent-y.jsonl", "agent-x"},
+		// Degenerate root: a "subagents" segment directly under filesystem root.
+		// filepath.Dir("/subagents") == "/" so the parent basename is "/" — locked
+		// in to document the boundary (never produced by real Claude Code paths).
+		{"/subagents/agent-y.jsonl", "/"},
 	}
 	for _, tt := range tests {
 		got := parentSessionIDFromPath(tt.path)

--- a/internal/repo/resolver_test.go
+++ b/internal/repo/resolver_test.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -125,6 +126,50 @@ func TestResolve_NonGitFallback(t *testing.T) {
 	}
 	if repo.URL != "" {
 		t.Errorf("got URL %q, want empty", repo.URL)
+	}
+}
+
+func TestResolve_GitToplevelNoRemote(t *testing.T) {
+	// A git repo with NO remote origin must resolve via the git-toplevel-basename
+	// path: FromGit=true, empty URL, SourceRank == SourceGitToplevel, ID == the
+	// working-tree basename. The other git-backed tests all run inside the
+	// claude-monitor checkout, which HAS a remote, so they take the remote-origin
+	// branch and leave this toplevel-only branch otherwise uncovered.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available:", err)
+	}
+
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, "local-only-repo")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "init", dir).CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+
+	r := NewResolver()
+	got, err := r.Resolve(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "local-only-repo" {
+		t.Errorf("ID = %q, want %q (git toplevel basename)", got.ID, "local-only-repo")
+	}
+	if got.Name != "local-only-repo" {
+		t.Errorf("Name = %q, want %q", got.Name, "local-only-repo")
+	}
+	if got.URL != "" {
+		t.Errorf("URL = %q, want empty (no remote origin)", got.URL)
+	}
+	if !got.FromGit {
+		t.Error("FromGit = false, want true for a git toplevel resolution")
+	}
+	if got.SourceRank() != SourceGitToplevel {
+		t.Errorf("SourceRank() = %d, want %d (SourceGitToplevel)", got.SourceRank(), SourceGitToplevel)
+	}
+	if got.Toplevel == "" {
+		t.Error("Toplevel is empty, want the git working-tree root")
 	}
 }
 

--- a/internal/store/backfill.go
+++ b/internal/store/backfill.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"bufio"
+	"database/sql"
 	"log"
 	"os"
 	"path/filepath"
@@ -17,8 +18,11 @@ import (
 const backfillMarkerKey = "backfill_v013_done"
 
 // agentFileRe matches a Claude Code agent transcript file base name:
-// "agent-<id>.jsonl". The captured group is the bare agent id.
-var agentFileRe = regexp.MustCompile(`^agent-(.+)\.jsonl$`)
+// "agent-<id>.jsonl". The captured group is the bare agent id, allowed to be
+// empty (.*), so the degenerate "agent-.jsonl" matches here exactly as it does
+// for the watcher's strings.HasPrefix(stem, "agent-") classification — the two
+// in-sync code paths must agree on what counts as an agent transcript.
+var agentFileRe = regexp.MustCompile(`^agent-(.*)\.jsonl$`)
 
 // Agent-kind classifications. These mirror the watcher's package-private
 // constants (internal/watcher/watcher.go:39-44) and pipeline path classification;
@@ -156,12 +160,22 @@ func (d *DB) RunBackfillV013(basePaths []string, force bool) (BackfillResult, er
 	// Guarded, additive UPDATE: only fills columns that are currently empty so a
 	// second run (or live ingestion having already populated them) changes nothing.
 	// Depends on migration 013 having added workflow_id/agent_id/agent_kind.
+	//
+	// The WHERE clause matches the row ONLY when at least one column is genuinely
+	// fillable (currently empty AND we have a non-empty value for it). Without this
+	// guard a CASE-only UPDATE still "affects" an already-populated row, so a forced
+	// re-run would report every unchanged row as Updated and log a spurious "linked"
+	// line. Gating on real change makes RowsAffected mean "a column was filled".
 	const updateSQL = `UPDATE sessions SET
-		parent_id  = CASE WHEN COALESCE(parent_id,'')  = '' THEN ? ELSE parent_id  END,
-		workflow_id = CASE WHEN COALESCE(workflow_id,'') = '' THEN ? ELSE workflow_id END,
-		agent_id   = CASE WHEN COALESCE(agent_id,'')   = '' THEN ? ELSE agent_id   END,
-		agent_kind = CASE WHEN COALESCE(agent_kind,'') = '' THEN ? ELSE agent_kind END
-		WHERE id = ?`
+		parent_id  = CASE WHEN COALESCE(parent_id,'')  = '' THEN :parent   ELSE parent_id  END,
+		workflow_id = CASE WHEN COALESCE(workflow_id,'') = '' THEN :workflow ELSE workflow_id END,
+		agent_id   = CASE WHEN COALESCE(agent_id,'')   = '' THEN :agent    ELSE agent_id   END,
+		agent_kind = CASE WHEN COALESCE(agent_kind,'') = '' THEN :kind     ELSE agent_kind END
+		WHERE id = :id
+		  AND ( (COALESCE(parent_id,'')   = '' AND :parent   <> '')
+		     OR (COALESCE(workflow_id,'') = '' AND :workflow <> '')
+		     OR (COALESCE(agent_id,'')    = '' AND :agent    <> '')
+		     OR (COALESCE(agent_kind,'')  = '' AND :kind     <> '') )`
 
 	for _, base := range basePaths {
 		if base == "" {
@@ -208,7 +222,13 @@ func (d *DB) RunBackfillV013(basePaths []string, force bool) (BackfillResult, er
 				parentID = ""
 			}
 
-			result, uerr := d.db.Exec(updateSQL, parentID, workflowID, agentID, kind, id)
+			result, uerr := d.db.Exec(updateSQL,
+				sql.Named("parent", parentID),
+				sql.Named("workflow", workflowID),
+				sql.Named("agent", agentID),
+				sql.Named("kind", kind),
+				sql.Named("id", id),
+			)
 			if uerr != nil {
 				res.Errors++
 				return nil
@@ -218,7 +238,9 @@ func (d *DB) RunBackfillV013(basePaths []string, force bool) (BackfillResult, er
 				res.Updated++
 				log.Printf("backfill: linked %s parent=%s workflow=%s kind=%s", id, parentID, workflowID, kind)
 			} else {
-				// No row with this id (session not ingested yet) — count Skipped.
+				// No column was filled: either no row with this id (session not
+				// ingested yet) or the row's identity columns are already populated
+				// (a forced re-run over a complete row). Either way, nothing changed.
 				res.Skipped++
 			}
 			return nil

--- a/internal/store/backfill_test.go
+++ b/internal/store/backfill_test.go
@@ -67,6 +67,15 @@ func TestClassifyAgentPath(t *testing.T) {
 			path:     "/proj/parentUUID/subagents/notes.jsonl",
 			wantKind: "",
 		},
+		{
+			// Degenerate empty-id "agent-.jsonl": must classify identically to the
+			// watcher's HasPrefix(stem, "agent-") path (subagent, full stem as id),
+			// not be skipped — the two in-sync code paths must agree.
+			name:        "degenerate empty-id agent file",
+			path:        "/proj/parentUUID/subagents/agent-.jsonl",
+			wantKind:    backfillKindSubagent,
+			wantAgentID: "agent-",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -252,6 +261,15 @@ func TestRunBackfillV013_Idempotent_NoClobber(t *testing.T) {
 	}
 	if res.Scanned != 1 {
 		t.Errorf("Scanned = %d, want 1 (force=true must walk even with marker set)", res.Scanned)
+	}
+	// The row is already fully populated, so the guarded UPDATE matches no row:
+	// nothing changed, so Updated must be 0 (not over-reported via RowsAffected)
+	// and the unchanged row is counted as Skipped instead.
+	if res.Updated != 0 {
+		t.Errorf("Updated = %d, want 0 (forced re-run over a populated row changes nothing)", res.Updated)
+	}
+	if res.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1 (the unchanged row)", res.Skipped)
 	}
 
 	after, err := db.GetSession("agent-AAA")

--- a/internal/store/migrations/registry.go
+++ b/internal/store/migrations/registry.go
@@ -8,6 +8,16 @@ import (
 )
 
 // Migration defines a schema change with Up (apply) and Down (rollback) functions.
+//
+// Convention for Down, especially for data/seed migrations (those that write or
+// correct row VALUES rather than only altering schema):
+//   - Make Down value-gated: revert only the rows whose values this migration set,
+//     identified by the exact value it wrote (e.g. UPDATE ... WHERE col = '<seed>').
+//     Never blindly clear or reset a column on rollback — that would clobber values
+//     a later run, live ingestion, or the user legitimately changed.
+//   - A pure schema migration may use a structural Down (DROP COLUMN / DROP INDEX).
+//   - Every migration's Up→Down→Up round-trip must be covered by a test (see the
+//     migration registry tests); 013 and 014 are the worked examples to copy.
 type Migration struct {
 	Name string
 	Up   func(*sql.Tx) error

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -3074,6 +3074,51 @@ func TestListReplayEvents_IncludesChildren(t *testing.T) {
 	}
 }
 
+// TestListReplayEvents_SameTimestampTiebreak locks in the secondary `e.id ASC`
+// sort: when a parent and child event share an identical timestamp, the merged
+// replay timeline must be deterministic rather than left to the engine's row
+// order. The parent event is persisted first (lower rowid), so it must sort first
+// despite the equal timestamp.
+func TestListReplayEvents_SameTimestampTiebreak(t *testing.T) {
+	t.Parallel()
+	db := openTestDB(t)
+
+	base := time.Now().UTC().Truncate(time.Second)
+	if err := db.SaveSession(&session.Session{ID: "p1", StartedAt: base, LastActive: base}); err != nil {
+		t.Fatalf("SaveSession(p1): %v", err)
+	}
+	if err := db.SaveSession(&session.Session{ID: "agent-1", ParentID: "p1", StartedAt: base, LastActive: base}); err != nil {
+		t.Fatalf("SaveSession(agent-1): %v", err)
+	}
+
+	// Both events carry the SAME timestamp; the parent is persisted first so it
+	// receives the lower autoincrement id.
+	batch := &EventBatch{Events: []EventInsert{
+		{SessionID: "p1", Event: &parser.Event{
+			Type: "assistant", Role: "assistant", ContentText: "parent msg",
+			Timestamp: base, UUID: "u-parent",
+		}},
+		{SessionID: "agent-1", Event: &parser.Event{
+			Type: "assistant", Role: "assistant", ContentText: "child msg",
+			Timestamp: base, UUID: "u-child",
+		}},
+	}}
+	if err := db.PersistBatch(batch); err != nil {
+		t.Fatalf("PersistBatch failed: %v", err)
+	}
+
+	replay, err := db.ListReplayEvents("p1", 1000, 0)
+	if err != nil {
+		t.Fatalf("ListReplayEvents failed: %v", err)
+	}
+	if len(replay) != 2 {
+		t.Fatalf("ListReplayEvents returned %d events, want 2", len(replay))
+	}
+	// Equal timestamps -> deterministic e.id ASC order: the parent (inserted first) wins.
+	if replay[0].ContentPreview != "parent msg" || replay[1].ContentPreview != "child msg" {
+		t.Errorf("same-timestamp order not by e.id ASC: [0]=%q [1]=%q", replay[0].ContentPreview, replay[1].ContentPreview)
+	}
+}
 
 // TestAggregateStats_WindowBoundaryUTC is a regression test for the time-window
 // boundary bug: started_at is stored as UTC RFC3339 ("…Z"), but the boundary was

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -12,6 +12,29 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+// waitTracked blocks until the watcher's initial scan has registered path in its
+// states map. Because ensureTracked adds the parent directory's fsnotify watch in
+// the same locked scan pass that populates states, observing the entry guarantees
+// the watch is live — so a subsequent append is certain to be picked up. This
+// replaces a fixed time.Sleep that only probabilistically allowed the initial scan
+// to finish, removing a theoretical flake under heavy CI load.
+func waitTracked(t *testing.T, w *Watcher, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		w.mu.Lock()
+		_, ok := w.states[path]
+		w.mu.Unlock()
+		if ok {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("watcher did not register %q within %s", path, timeout)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
 // newTestWatcher creates a Watcher with only the given paths (no defaultBasePaths).
 // This isolates tests from real session files on the host machine.
 func newTestWatcher(t *testing.T, paths []string) *Watcher {
@@ -124,7 +147,9 @@ func TestWatcher_EmitsWorkflowIdentity(t *testing.T) {
 	defer cancel()
 
 	events := w.Start(ctx)
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the initial scan registers the file (and its fsnotify watch)
+	// before appending, instead of sleeping a fixed interval.
+	waitTracked(t, w, jsonlPath, 2*time.Second)
 
 	line := `{"type":"user","message":{"role":"user","content":"workflow line"},"sessionId":"parent-uuid","uuid":"uuid-wf1","isSidechain":true,"timestamp":"2024-01-01T00:00:00Z"}`
 	af, err := os.OpenFile(jsonlPath, os.O_APPEND|os.O_WRONLY, 0644)
@@ -214,8 +239,10 @@ func TestWatcher_EmitsEventsForAppendedLines(t *testing.T) {
 
 	events := w.Start(ctx)
 
-	// Give the watcher time to do its initial scan and register the file.
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the initial scan has registered the file (and thus added the
+	// parent-dir fsnotify watch) before appending. Synchronising on observed state
+	// rather than a fixed sleep makes the scan-ordering deterministic.
+	waitTracked(t, w, jsonlPath, 2*time.Second)
 
 	// Append a valid JSONL line to the file.
 	wantLine := `{"type":"user","message":{"role":"user","content":"hello watcher"},"sessionId":"test-session","uuid":"uuid-w1","timestamp":"2024-01-01T00:00:00Z"}`

--- a/web/src/components/history-view.test.ts
+++ b/web/src/components/history-view.test.ts
@@ -72,4 +72,29 @@ describe('groupRows', () => {
     const childIds = groups[0].children.map((c) => c.id).sort();
     expect(childIds).toEqual(['c', 'gc']);
   });
+
+  it('flattens a 4+-level chain entirely under the top-level ancestor', () => {
+    // gp -> c -> gc -> ggc: the ancestor walk must climb past every intermediate
+    // level, not just one, so all descendants collapse under the single root.
+    const gp = makeSession({ id: 'gp', lastActive: '2024-01-01T09:00:00Z' });
+    const c = makeSession({ id: 'c', parentId: 'gp', lastActive: '2024-01-01T08:00:00Z' });
+    const gc = makeSession({ id: 'gc', parentId: 'c', lastActive: '2024-01-01T07:00:00Z' });
+    const ggc = makeSession({ id: 'ggc', parentId: 'gc', lastActive: '2024-01-01T06:00:00Z' });
+
+    const groups = groupRows([gp, c, gc, ggc]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].parent.id).toBe('gp');
+    expect(groups[0].children.map((x) => x.id).sort()).toEqual(['c', 'gc', 'ggc']);
+  });
+
+  it('terminates on a parentId cycle (depth guard)', () => {
+    // a <-> b form a parentId cycle. The ancestor walk is bounded by the depth
+    // guard, so groupRows must return rather than loop forever. Neither node has a
+    // root parent (each claims an in-set parent), so there are no top-level rows.
+    const a = makeSession({ id: 'a', parentId: 'b', lastActive: '2024-01-01T02:00:00Z' });
+    const b = makeSession({ id: 'b', parentId: 'a', lastActive: '2024-01-01T01:00:00Z' });
+
+    const groups = groupRows([a, b]);
+    expect(groups).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary

Works through the [#222](https://github.com/Zxela/claude-monitor/issues/222) handoff — the low/nit tail of the #218–#221 workflow-logging audit. Each item was re-verified against current `main` before acting; some were already addressed by later commits, some confirmed unreachable, and the genuinely worthwhile ones are fixed here.

## Code fixes

- **#219** — `pipeline.resolveParentID`: the second `pendingParentLinks` write (the `msg.ParentUUID` fallback) now carries the same `!ok` set-once guard as its in-content sibling, so both deferred-link write sites share one policy.
- **#220** — `pipeline` restart rehydration: the `isNew` block now restores `ParentID/WorkflowID/AgentID/AgentKind` from the persisted row, so a first post-restart line that carries no parent signal (e.g. a lone summary line) no longer briefly broadcasts a subagent with an empty `ParentID`.
- **#220** — `store/backfill`: the guarded UPDATE now matches a row **only when a column is genuinely fillable**, so `RowsAffected` means "a column was filled." A forced re-run over already-populated rows no longer over-reports `Updated` or logs spurious `linked` lines (`updated=1` first run → `updated=0 skipped=1` on re-run).
- **#220** — `store/backfill`: `agentFileRe` `.+`→`.*` so the degenerate `agent-.jsonl` classifies identically to the watcher's `HasPrefix(stem, "agent-")` — the two explicitly-in-sync paths now agree.
- **cross-cutting** — codified the "value-gated, tested `Down`" convention on the `Migration` struct doc, where every future migration author looks.

## Test additions (genuinely untested branches)

- **#218** — replaced the fixed `time.Sleep(100ms)` in the appended-lines and workflow-identity watcher tests with a `waitTracked` white-box poll on `states` (which implies the fsnotify dir watch is live). Removes a theoretical scan-ordering flake; no production change. Passes `-race -count=5`.
- **#219** — `TestResolve_GitToplevelNoRemote` (`git init`, no remote) covers the git-toplevel-basename branch: `ID==basename`, `URL==""`, `FromGit`, `SourceRank()==SourceGitToplevel`.
- **#219** — `parentSessionIDFromPath`: nested-subagents + degenerate-root walk cases.
- **#220** — `TestListReplayEvents_SameTimestampTiebreak` locks the secondary `e.id ASC` sort.
- **#221** — `groupRows`: cycle-guard (depth bound) + 4+-level chain.

## Checked but deliberately *not* changed

- **#219 `pendingParentLinks` leak** — confirmed unreachable for normal sessions (`resolveParentID` early-returns before the deferred write); only orphan sidechain subagents could linger (bounded/rare). No eviction added, matching "only if real."
- **#219 `applyRepoResolution` round-trip** — the upgrade logic already has 3 direct-call tests and `TestApplyRepoResolution_RestartReupsertPreservesMetadata` already round-trips through `ListRepos`. A full `Process()` upgrade round-trip needs cross-event git control → flaky for no added confidence. (Path-walk half is done above.)
- **#220 query/API edges** — `/api/workflows` shape (`TestWorkflows`) and the workflow filter (`TestSessionsWorkflowFilter`) already exist; `?workflow=` vs `?repo=` precedence isn't meaningfully unit-testable against the empty-DB handler harness.
- **#221 `errors-filter` local mirror / `hub_test` goroutine count** — true nits (faithful / already-mitigated); churn > value.

## Testing

- `go test ./... -count=1` ✅ · `go vet ./...` ✅ · `-race` clean on pipeline/watcher/store/repo
- `web`: `tsc --noEmit` ✅ · `typecheck:test` ✅ · `lint` ✅ (warnings pre-existing) · `vitest run` 45/45 ✅

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
