### PR TITLE
fix: index the tool_use→tool_result self-join so tool/skill stats stop scanning whole sessions

### DIFF
--- a/internal/store/migrations/019_tool_result_join_index.go
+++ b/internal/store/migrations/019_tool_result_join_index.go
@@ -1,0 +1,31 @@
+package migrations
+
+import "database/sql"
+
+func init() {
+	Register(19, Migration{
+		Name: "tool_result_join_index",
+		Up: func(tx *sql.Tx) error {
+			// ToolUsage and SessionSkills attribute errors by self-joining each
+			// tool_use event to its tool_result via
+			//   r.for_tool_use_id = u.tool_use_id AND r.session_id = u.session_id
+			// Without an index on for_tool_use_id the planner resolves the join
+			// through idx_events_dedup (session_id only), scanning every event in
+			// the session per tool_use row — multi-second /api/stats/tools and
+			// /api/skills/sessions on grown databases. Including is_error makes
+			// the index covering, so the join never touches the table.
+			//
+			// Deliberately not a partial index (WHERE for_tool_use_id != ''):
+			// the planner cannot prove the join's u.tool_use_id != '' guard
+			// implies r.for_tool_use_id != '' through the equality, so it would
+			// ignore the index entirely.
+			_, err := tx.Exec(`CREATE INDEX idx_events_result_lookup
+				ON events(for_tool_use_id, session_id, is_error)`)
+			return err
+		},
+		Down: func(tx *sql.Tx) error {
+			_, err := tx.Exec(`DROP INDEX IF EXISTS idx_events_result_lookup`)
+			return err
+		},
+	})
+}

--- a/internal/store/migrations/019_tool_result_join_index.go
+++ b/internal/store/migrations/019_tool_result_join_index.go
@@ -19,7 +19,9 @@ func init() {
 			// the planner cannot prove the join's u.tool_use_id != '' guard
 			// implies r.for_tool_use_id != '' through the equality, so it would
 			// ignore the index entirely.
-			_, err := tx.Exec(`CREATE INDEX idx_events_result_lookup
+			// IF NOT EXISTS: tolerate databases where the index was applied
+			// out-of-band (e.g. as a manual hotfix) so startup doesn't wedge.
+			_, err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_events_result_lookup
 				ON events(for_tool_use_id, session_id, is_error)`)
 			return err
 		},

--- a/internal/store/migrations/registry_test.go
+++ b/internal/store/migrations/registry_test.go
@@ -19,6 +19,22 @@ func openTestDB(t *testing.T) *sql.DB {
 	return db
 }
 
+// rollDownTo rolls back migrations one at a time until the named migration has
+// been rolled back, so tests targeting a specific migration's Down don't break
+// every time a new head migration is added.
+func rollDownTo(t *testing.T, db *sql.DB, name string) {
+	t.Helper()
+	for {
+		got, err := RunDown(db)
+		if err != nil {
+			t.Fatalf("RunDown: %v", err)
+		}
+		if got == name {
+			return
+		}
+	}
+}
+
 func TestGetVersion_FreshDB(t *testing.T) {
 	db := openTestDB(t)
 	v, err := GetVersion(db)
@@ -249,7 +265,7 @@ func TestOpus48Pricing_SeededAndReversible(t *testing.T) {
 
 	// Roll back the migrations above 014 (newest first) so 014 becomes the head,
 	// then roll back 014 itself.
-	for _, want := range []string{"fable_5_pricing", "reattribute_child_repos", "rebuild_events_fts", "recompute_session_aggregates"} {
+	for _, want := range []string{"tool_result_join_index", "fable_5_pricing", "reattribute_child_repos", "rebuild_events_fts", "recompute_session_aggregates"} {
 		name, err := RunDown(db)
 		if err != nil {
 			t.Fatalf("RunDown: %v", err)
@@ -352,14 +368,8 @@ func TestFable5Pricing_SeededAndReversible(t *testing.T) {
 		t.Errorf("cache_create_per_mtok = %v, want 12.50", cacheCreate)
 	}
 
-	// 018 is the head migration; one RunDown rolls it back.
-	name, err := RunDown(db)
-	if err != nil {
-		t.Fatalf("RunDown: %v", err)
-	}
-	if name != "fable_5_pricing" {
-		t.Fatalf("RunDown rolled back %q, want fable_5_pricing", name)
-	}
+	// Roll back through head until 018 itself is rolled back.
+	rollDownTo(t, db, "fable_5_pricing")
 
 	// The fable-5 row must be gone.
 	var n int
@@ -395,10 +405,8 @@ func TestFable5Pricing_DownPreservesUserEditedRow(t *testing.T) {
 		t.Fatalf("simulate user edit: %v", err)
 	}
 
-	// 018 is the head migration; one RunDown rolls it back.
-	if _, err := RunDown(db); err != nil {
-		t.Fatalf("RunDown: %v", err)
-	}
+	// Roll back through head until 018 itself is rolled back.
+	rollDownTo(t, db, "fable_5_pricing")
 
 	// The user-edited row must survive the rollback, untouched.
 	var in, out float64
@@ -626,5 +634,31 @@ func TestMigration013_DownRoundTrip(t *testing.T) {
 	}
 	if !indexExists(t, db, "idx_sessions_workflow") {
 		t.Error("after re-RunUp: idx_sessions_workflow not restored")
+	}
+}
+
+// TestToolResultJoinIndex_UpDown verifies migration 019 creates the covering
+// index used by the ToolUsage/SessionSkills tool_use→tool_result self-join,
+// and that rolling it back removes it.
+func TestToolResultJoinIndex_UpDown(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("RunUp: %v", err)
+	}
+	if !indexExists(t, db, "idx_events_result_lookup") {
+		t.Fatal("idx_events_result_lookup missing after RunUp")
+	}
+
+	rollDownTo(t, db, "tool_result_join_index")
+	if indexExists(t, db, "idx_events_result_lookup") {
+		t.Error("idx_events_result_lookup should be dropped after RunDown")
+	}
+
+	// Re-apply to head — must cleanly re-create the index.
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("re-RunUp: %v", err)
+	}
+	if !indexExists(t, db, "idx_events_result_lookup") {
+		t.Error("idx_events_result_lookup not restored after re-RunUp")
 	}
 }

--- a/internal/store/migrations/registry_test.go
+++ b/internal/store/migrations/registry_test.go
@@ -263,26 +263,8 @@ func TestOpus48Pricing_SeededAndReversible(t *testing.T) {
 		t.Errorf("cache_create_per_mtok = %v, want 6.25", cacheCreate)
 	}
 
-	// Roll back the migrations above 014 (newest first) so 014 becomes the head,
-	// then roll back 014 itself.
-	for _, want := range []string{"tool_result_join_index", "fable_5_pricing", "reattribute_child_repos", "rebuild_events_fts", "recompute_session_aggregates"} {
-		name, err := RunDown(db)
-		if err != nil {
-			t.Fatalf("RunDown: %v", err)
-		}
-		if name != want {
-			t.Fatalf("RunDown rolled back %q, want %q", name, want)
-		}
-	}
-
-	// Roll back migration 014.
-	name, err := RunDown(db)
-	if err != nil {
-		t.Fatalf("RunDown: %v", err)
-	}
-	if name != "opus_4_8_pricing" {
-		t.Fatalf("RunDown rolled back %q, want opus_4_8_pricing", name)
-	}
+	// Roll back through head until 014 itself is rolled back.
+	rollDownTo(t, db, "opus_4_8_pricing")
 
 	// The opus-4-8 row must be gone.
 	var n int
@@ -319,9 +301,10 @@ func TestOpus48Pricing_DownPreservesUserEditedRow(t *testing.T) {
 		t.Fatalf("simulate user edit: %v", err)
 	}
 
-	if _, err := RunDown(db); err != nil {
-		t.Fatalf("RunDown: %v", err)
-	}
+	// Roll back through head until 014 itself is rolled back. (A single bare
+	// RunDown here only rolled back whatever the head migration was, so this
+	// test was vacuous — 014's Down never actually ran.)
+	rollDownTo(t, db, "opus_4_8_pricing")
 
 	// The user-edited row must survive the rollback, untouched.
 	var in, out float64


### PR DESCRIPTION
## Problem

`/api/stats/tools` and `/api/skills/sessions` remained multi-second (~4s uncontended on a 349MB database) after #245 unblocked them from the write queue — the follow-up called out in that PR.

`ToolUsage` and `SessionSkills` attribute errors by self-joining each `tool_use` event to its `tool_result` via `r.for_tool_use_id = u.tool_use_id AND r.session_id = u.session_id`. No index covers `for_tool_use_id`, so the planner resolves the join with `SEARCH r USING idx_events_dedup (session_id=?)` — for each of ~19k tool_use rows it scans every event in that row's session checking `for_tool_use_id` by hand. Effectively quadratic in session size, and it degrades as the database grows.

## Fix

Migration 019 adds a covering index:

```sql
CREATE INDEX idx_events_result_lookup ON events(for_tool_use_id, session_id, is_error);
```

The plan becomes `SEARCH r USING COVERING INDEX (for_tool_use_id=? AND session_id=?)` — direct lookup, never touching the table since `is_error` is included.

**Benchmarked on a `.backup` copy of the production database (349MB, 161k events): 4.11s → 0.068s (60×), byte-identical results.** Index build took ~1s during migration; size cost is a few MB.

Note: a partial index (`WHERE for_tool_use_id != ''`) does **not** work — the planner can't prove the join's `u.tool_use_id != ''` guard implies it through the equality, and ignores the index (verified: plan unchanged).

## Testing

- New `TestToolResultJoinIndex_UpDown`: index exists after `RunUp`, gone after rolling back 019, restored on re-`RunUp`.
- Head-migration-dependent tests (`TestFable5Pricing_*`) now roll down via a `rollDownTo` helper instead of assuming 018 is head, so future head migrations stop breaking them; `TestOpus48Pricing_SeededAndReversible`'s ordered rollback list gains 019.
- Full `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)