### PR TITLE
fix: preserve history scroll position across re-renders

### DIFF
--- a/web/src/components/history-view.ts
+++ b/web/src/components/history-view.ts
@@ -142,11 +142,15 @@ function onStateChange(_state: AppState, changed: Set<string>): void {
 
 async function loadData(append = false): Promise<void> {
   if (state.view !== 'history') return; // Guard against stale timer callbacks
-  if (append) {
-    if (reachedEnd || loadingMore) return;
-    loadingMore = true;
-  } else {
-    // First load or refresh: start over from page 0 so new sessions appear.
+  if (loadingMore) return; // a page append or refresh is already in flight
+  if (append && reachedEnd) return;
+  loadingMore = true;
+  // Append loads exactly one more page. Refresh refetches every page already
+  // on screen (the server caps limit at 500, so it pages in PAGE chunks)
+  // instead of collapsing back to page 1 — a background refresh must not
+  // shrink the list out from under a user who has scrolled deep.
+  const target = append ? offset + PAGE : Math.max(offset, PAGE);
+  if (!append) {
     offset = 0;
     reachedEnd = false;
     seenIds.clear();
@@ -166,17 +170,19 @@ async function loadData(append = false): Promise<void> {
       });
   }
   try {
-    const raw = await fetchSessions(PAGE, offset);
-    if (state.view !== 'history') return; // Re-check after async
-    if (raw.length < PAGE) reachedEnd = true;
-    offset += PAGE;
-    // Filter out trivial sessions (no cost, no tokens, few messages) and dedupe
-    // by id so an overlapping/refetched page never produces duplicate rows.
-    for (const s of raw) {
-      if (seenIds.has(s.id)) continue;
-      if (!(s.totalCost > 0 || s.inputTokens > 0 || s.messageCount > 3)) continue;
-      seenIds.add(s.id);
-      data.push(s);
+    while (offset < target && !reachedEnd) {
+      const raw = await fetchSessions(PAGE, offset);
+      if (state.view !== 'history') return; // Re-check after async
+      if (raw.length < PAGE) reachedEnd = true;
+      offset += PAGE;
+      // Filter out trivial sessions (no cost, no tokens, few messages) and dedupe
+      // by id so an overlapping/refetched page never produces duplicate rows.
+      for (const s of raw) {
+        if (seenIds.has(s.id)) continue;
+        if (!(s.totalCost > 0 || s.inputTokens > 0 || s.messageCount > 3)) continue;
+        seenIds.add(s.id);
+        data.push(s);
+      }
     }
     show();
   } catch (err) {
@@ -279,8 +285,15 @@ function workflowSummary(children: Session[]): { id: string; count: number; cost
   return [...byWorkflow.values()];
 }
 
-function show(): void {
+function show(resetScroll = false): void {
   if (!container) return;
+  // show() rebuilds the whole .view-overlay scroll container, which resets
+  // scrollTop to 0 — so carry the position over to the new element. Otherwise
+  // paging in more rows (or a background refresh) teleports the user to the
+  // top. resetScroll opts out for re-renders where the old position is
+  // meaningless, e.g. re-sorting.
+  const prevOverlay = container.querySelector('.view-overlay');
+  const prevScroll = !resetScroll && prevOverlay ? prevOverlay.scrollTop : 0;
   container.innerHTML = '';
 
   const wrapper = document.createElement('div');
@@ -346,7 +359,8 @@ function show(): void {
         sortCol = col.key;
         sortAsc = false;
       }
-      show();
+      // Re-sorting reorders every row, so jump to the top of the new order.
+      show(true);
     };
     th.addEventListener('click', sortByCol);
     th.addEventListener('keydown', (e) => {
@@ -503,6 +517,7 @@ function show(): void {
   }
 
   container.appendChild(wrapper);
+  if (prevScroll > 0) wrapper.scrollTop = prevScroll;
 }
 
 // mergeSkills combines several per-session skill lists into one, summing uses


### PR DESCRIPTION
## Problem

On the history page, scrolling to the bottom jumped back to the top. `show()` rebuilds the entire `.view-overlay` scroll container on every re-render (`container.innerHTML = ''`), destroying its `scrollTop`. So the moment the infinite-scroll sentinel loaded the next page — or LOAD MORE was clicked — the rebuilt container mounted at scroll position 0.

A second path had the same symptom: the debounced 5s background refresh (`changed.has('sessions')`) reset pagination to page 1 and re-rendered, yanking a deep-scrolled user to the top and discarding their loaded pages.

## Fix

- `show()` captures the previous overlay's `scrollTop` and restores it on the new one. Appending a page, the skills badge arriving, collapse toggles, and background refreshes all keep the user where they were.
- Re-sorting opts out via `show(true)` — reordering every row makes the old position meaningless, so the column-header click jumps to the top of the new order (standard table behavior).
- The background refresh now refetches **all previously loaded pages** (looping in `PAGE`-sized chunks since the server caps `limit` at 500) instead of collapsing back to page 1, so a refresh is invisible rather than destructive.
- Loads are serialized behind a single in-flight guard (`loadingMore`) so a refresh and a sentinel-triggered append can't interleave and double-mutate `data`.

## Effect on filtering/sorting

Sorting and the subagent filters are client-side over the loaded rows and are unaffected logically; sort explicitly resets scroll, filter/collapse toggles preserve it.

## Testing

- `npx tsc --noEmit` clean; all 45 web tests pass.
- Live Playwright verification against a copy of a production DB (built binary, sandboxed $HOME): scrolled to bottom (scrollTop 2756) → sentinel loaded page 2 (199→396 sessions, DOM fully rebuilt) → scroll position unchanged at 2756. Sort click from mid-list → scrollTop 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)