### PR TITLE
fix: correct opus-4-8 pricing, heal inflated costs and restart-doubled error counts

### DIFF
--- a/cmd/claude-monitor/handlers.go
+++ b/cmd/claude-monitor/handlers.go
@@ -635,7 +635,7 @@ func handleSessionAutopsy(sessionStore *session.Store, historyDB *store.DB) http
 			sess = row.ToSession()
 		}
 
-		events, err := historyDB.ListEvents(id, 5000, 0)
+		events, err := historyDB.ListEvents(id, autopsyEventLimit, 0)
 		if err != nil {
 			writeJSONError(w, "failed to list session events", http.StatusInternalServerError)
 			return
@@ -648,6 +648,10 @@ func handleSessionAutopsy(sessionStore *session.Store, historyDB *store.DB) http
 		_, _ = w.Write([]byte(report))
 	}
 }
+
+// autopsyEventLimit caps the event scan for command/error extraction; the
+// report notes when a session exceeds it instead of truncating silently.
+const autopsyEventLimit = 5000
 
 func buildSessionAutopsyMarkdown(sess *session.Session, events []store.EventRow) string {
 	const (
@@ -711,6 +715,12 @@ func buildSessionAutopsyMarkdown(sess *session.Session, events []store.EventRow)
 		for _, errLine := range errors {
 			fmt.Fprintf(&sb, "- %s\n", errLine)
 		}
+		if sess.ErrorCount > len(errors) {
+			fmt.Fprintf(&sb, "\n_Showing %d of %d errors._\n", len(errors), sess.ErrorCount)
+		}
+	}
+	if len(events) >= autopsyEventLimit {
+		fmt.Fprintf(&sb, "\n_Note: command and error extraction scanned the first %d events; the session has more._\n", autopsyEventLimit)
 	}
 
 	return sb.String()
@@ -752,7 +762,10 @@ func formatRFC3339(t time.Time) string {
 	if t.IsZero() {
 		return "n/a"
 	}
-	return t.Format(time.RFC3339)
+	// Normalize to UTC: StartedAt and LastActive can carry different zones
+	// (DB rows parse as UTC, live sessions hold local time), which previously
+	// rendered mixed-timezone Started/Ended lines in the same report.
+	return t.UTC().Format(time.RFC3339)
 }
 
 func sessionDuration(sess *session.Session) string {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -188,6 +188,7 @@ type modelPricing struct {
 // pricingTable is the compile-time fallback used when the DB is empty or unavailable.
 var pricingTable = map[string]modelPricing{
 	"claude-fable-5":    {10.0, 50.0, 1.0, 12.50},
+	"claude-opus-4-8":   {5.0, 25.0, 0.50, 6.25},
 	"claude-opus-4-7":   {5.0, 25.0, 0.50, 6.25},
 	"claude-opus-4-6":   {5.0, 25.0, 0.50, 6.25},
 	"claude-opus-4-5":   {5.0, 25.0, 0.50, 6.25},

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -508,6 +508,8 @@ func TestComputeCost_ByModel(t *testing.T) {
 		{"fable", "claude-fable-5", 10.0 + 50.0 + 1.0 + 12.50},
 		{"fable 1m suffix", "claude-fable-5[1m]", 10.0 + 50.0 + 1.0 + 12.50},
 		{"opus", "claude-opus-4-6", 5.0 + 25.0 + 0.50 + 6.25},
+		{"opus 4.8", "claude-opus-4-8", 5.0 + 25.0 + 0.50 + 6.25},
+		{"opus 4.8 versioned", "claude-opus-4-8-20260101", 5.0 + 25.0 + 0.50 + 6.25},
 		{"sonnet", "claude-sonnet-4-6", 3.0 + 15.0 + 0.30 + 3.75},
 		{"haiku", "claude-haiku-4-5", 1.0 + 5.0 + 0.10 + 1.25},
 		{"haiku versioned", "claude-haiku-4-5-20251001", 1.0 + 5.0 + 0.10 + 1.25},

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -151,6 +151,15 @@ func (p *Pipeline) Process(ev watcher.Event) {
 		// After a restart, in-memory dedup maps are empty, which would cause
 		// duplicate events to double-count costs, messages, and errors.
 		if ids, costs, err := p.db.LoadMessageDedup(ev.SessionID); err == nil && len(ids) > 0 {
+			// Seed the "err:" dedup keys from persisted error events. Without
+			// them, bootstrap replay of the JSONL re-fires ErrorCount++ for every
+			// historical error line on top of the recounted baseline below —
+			// doubling sessions.error_count on every restart.
+			if errIDs, errIDsErr := p.db.LoadErrorDedup(ev.SessionID); errIDsErr == nil {
+				for _, id := range errIDs {
+					ids["err:"+id] = true
+				}
+			}
 			// Also restore session aggregates so totals aren't reset to zero.
 			dbSess, _ := p.db.GetSession(ev.SessionID)
 			// Recompute the cost/token aggregates from the SAME per-message map
@@ -496,8 +505,13 @@ func (p *Pipeline) applySessionMeta(s *session.Session, msg *parser.Event, ev wa
 		s.SessionName = msg.ContentText
 	}
 
-	// Task description from first user message
-	if s.TaskDescription == "" && msg.Role == "user" && msg.ContentText != "" {
+	// Task description from the first user message that is actual user prose.
+	// Local-command echoes and harness-injected blocks (<local-command-caveat>,
+	// <command-name>, <system-reminder>, …) arrive as user-role lines before the
+	// real task; taking one of those produced garbage Task lines in History and
+	// the autopsy. Skip them and wait for the next user message.
+	if s.TaskDescription == "" && msg.Role == "user" && msg.ContentText != "" &&
+		!isHarnessInjectedContent(msg.ContentText) {
 		desc := msg.ContentText
 		if len([]rune(desc)) > 200 {
 			desc = string([]rune(desc)[:200])
@@ -636,6 +650,23 @@ func (p *Pipeline) applyParentDetection(s *session.Session, msg *parser.Event, e
 }
 
 // applyCostDedup handles error tracking, cost/token dedup, and message counting.
+// isHarnessInjectedContent reports whether a user-role message body is a
+// harness artifact rather than user prose: local-command echoes, caveat
+// wrappers, system reminders, and task notifications all arrive as user-role
+// lines and must not become a session's TaskDescription.
+func isHarnessInjectedContent(text string) bool {
+	t := strings.TrimSpace(text)
+	for _, tag := range []string{
+		"<local-command-", "<command-", "<system-reminder>",
+		"<task-notification>", "<user-prompt-submit-hook>",
+	} {
+		if strings.HasPrefix(t, tag) {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *Pipeline) applyCostDedup(s *session.Session, msg *parser.Event) {
 	// Error tracking. Dedup on the stable event identity (message_id, else the
 	// per-line uuid) so a re-emitted error line cannot be counted twice and an

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -150,7 +150,13 @@ func (p *Pipeline) Process(ev watcher.Event) {
 		// Rebuild dedup state from DB if this session was previously persisted.
 		// After a restart, in-memory dedup maps are empty, which would cause
 		// duplicate events to double-count costs, messages, and errors.
-		if ids, costs, err := p.db.LoadMessageDedup(ev.SessionID); err == nil && len(ids) > 0 {
+		// Gate on the session existing in the DB (not on len(ids) > 0): a
+		// session whose only persisted events are errors has no message-id'd
+		// rows, but its err: dedup keys and error_count still need rebuilding
+		// or replay re-inflates the count on every restart.
+		ids, costs, dedupErr := p.db.LoadMessageDedup(ev.SessionID)
+		dbSess, _ := p.db.GetSession(ev.SessionID)
+		if dedupErr == nil && (len(ids) > 0 || dbSess != nil) {
 			// Seed the "err:" dedup keys from persisted error events. Without
 			// them, bootstrap replay of the JSONL re-fires ErrorCount++ for every
 			// historical error line on top of the recounted baseline below —
@@ -160,8 +166,6 @@ func (p *Pipeline) Process(ev watcher.Event) {
 					ids["err:"+id] = true
 				}
 			}
-			// Also restore session aggregates so totals aren't reset to zero.
-			dbSess, _ := p.db.GetSession(ev.SessionID)
 			// Recompute the cost/token aggregates from the SAME per-message map
 			// just rebuilt from events, rather than copying the stored sessions
 			// columns. The stored values can be stale (e.g. accumulated across

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1845,3 +1845,57 @@ func TestProcess_RebuildErrorDedupFromDB(t *testing.T) {
 		t.Errorf("ErrorCount after new error = %d, want 2", sess2.ErrorCount)
 	}
 }
+
+// TestProcess_RebuildErrorDedupFromDB_ErrorsOnlySession covers the shape the
+// first fix missed: a session whose ONLY persisted events are errors (e.g. an
+// agent that crashed before its first costed turn) has no message-id'd rows,
+// so the rebuild must be gated on the DB session row, not on the message
+// dedup map being non-empty.
+func TestProcess_RebuildErrorDedupFromDB_ErrorsOnlySession(t *testing.T) {
+	db := openTestDB(t)
+	resolver := repo.NewResolver()
+	const sid = "err-only-rebuild-test"
+	ts := time.Now()
+
+	errorLine := makeJSONL(t, map[string]interface{}{
+		"type":      "user",
+		"uuid":      "uuid-only-err",
+		"timestamp": ts.Format(time.RFC3339Nano),
+		"sessionId": sid,
+		"message": map[string]interface{}{
+			"role": "user",
+			"content": []map[string]interface{}{
+				{
+					"type":        "tool_result",
+					"tool_use_id": "toolu_only",
+					"is_error":    true,
+					"content":     "Error: crashed before first turn",
+				},
+			},
+		},
+	})
+
+	sessions1 := session.NewStore()
+	p1 := New(sessions1, db, resolver, nil)
+	p1.Process(watcher.Event{SessionID: sid, Line: errorLine, Bootstrap: true})
+	p1.Stop()
+
+	sess1, _ := sessions1.Get(sid)
+	if sess1 == nil || sess1.ErrorCount != 1 {
+		t.Fatalf("phase 1 ErrorCount = %v, want 1", sess1)
+	}
+
+	// Restart and replay the same line.
+	sessions2 := session.NewStore()
+	p2 := New(sessions2, db, resolver, nil)
+	defer p2.Stop()
+	p2.Process(watcher.Event{SessionID: sid, Line: errorLine, Bootstrap: true})
+
+	sess2, ok := sessions2.Get(sid)
+	if !ok {
+		t.Fatal("session not found after replay")
+	}
+	if sess2.ErrorCount != 1 {
+		t.Errorf("ErrorCount after replay = %d, want 1 (errors-only session must rebuild err: keys)", sess2.ErrorCount)
+	}
+}

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -1756,3 +1756,92 @@ func TestSameRepo(t *testing.T) {
 		})
 	}
 }
+
+// TestProcess_RebuildErrorDedupFromDB verifies that error_count does not
+// inflate when the JSONL is replayed after a restart: the "err:" dedup keys
+// are reseeded from persisted error events (LoadErrorDedup), so the bootstrap
+// replay of an already-counted error line must not re-increment ErrorCount.
+func TestProcess_RebuildErrorDedupFromDB(t *testing.T) {
+	db := openTestDB(t)
+	resolver := repo.NewResolver()
+	const sid = "err-dedup-rebuild-test"
+	ts := time.Now()
+
+	errorLine := func(uuid string) []byte {
+		return makeJSONL(t, map[string]interface{}{
+			"type":      "user",
+			"uuid":      uuid,
+			"timestamp": ts.Format(time.RFC3339Nano),
+			"sessionId": sid,
+			"message": map[string]interface{}{
+				"role": "user",
+				"content": []map[string]interface{}{
+					{
+						"type":        "tool_result",
+						"tool_use_id": "toolu_" + uuid,
+						"is_error":    true,
+						"content":     "Error: command failed",
+					},
+				},
+			},
+		})
+	}
+
+	// An assistant message with a message ID, so the restart-rebuild path
+	// (which only fires when LoadMessageDedup returns entries) actually runs —
+	// that is the real-world shape where the inflation occurred.
+	assistantLine := makeJSONL(t, map[string]interface{}{
+		"type":      "assistant",
+		"uuid":      "uuid-asst-1",
+		"timestamp": ts.Format(time.RFC3339Nano),
+		"sessionId": sid,
+		"message": map[string]interface{}{
+			"id":      "msg-err-test",
+			"role":    "assistant",
+			"content": "working on it",
+			"usage": map[string]interface{}{
+				"input_tokens":  100,
+				"output_tokens": 50,
+			},
+			"model":       "claude-sonnet-4-6",
+			"stop_reason": "end_turn",
+		},
+	})
+
+	// --- Phase 1: count one error and persist. ---
+	sessions1 := session.NewStore()
+	p1 := New(sessions1, db, resolver, nil)
+	p1.Process(watcher.Event{SessionID: sid, Line: assistantLine, Bootstrap: true})
+	p1.Process(watcher.Event{SessionID: sid, Line: errorLine("uuid-err-1"), Bootstrap: true})
+	p1.Stop() // flushes to DB
+
+	sess1, ok := sessions1.Get(sid)
+	if !ok {
+		t.Fatal("session not found after phase 1")
+	}
+	if sess1.ErrorCount != 1 {
+		t.Fatalf("phase 1 ErrorCount = %d, want 1", sess1.ErrorCount)
+	}
+
+	// --- Phase 2: restart — fresh store, same DB, full JSONL replay. ---
+	sessions2 := session.NewStore()
+	p2 := New(sessions2, db, resolver, nil)
+	defer p2.Stop()
+	p2.Process(watcher.Event{SessionID: sid, Line: assistantLine, Bootstrap: true})
+	p2.Process(watcher.Event{SessionID: sid, Line: errorLine("uuid-err-1"), Bootstrap: true})
+
+	sess2, ok := sessions2.Get(sid)
+	if !ok {
+		t.Fatal("session not found after phase 2")
+	}
+	if sess2.ErrorCount != 1 {
+		t.Errorf("ErrorCount after replay = %d, want 1 (err: dedup keys must survive restart)", sess2.ErrorCount)
+	}
+
+	// A genuinely new error after the restart must still count.
+	p2.Process(watcher.Event{SessionID: sid, Line: errorLine("uuid-err-2"), Bootstrap: true})
+	sess2, _ = sessions2.Get(sid)
+	if sess2.ErrorCount != 2 {
+		t.Errorf("ErrorCount after new error = %d, want 2", sess2.ErrorCount)
+	}
+}

--- a/internal/store/migrations/020_fix_opus_4_8_pricing.go
+++ b/internal/store/migrations/020_fix_opus_4_8_pricing.go
@@ -1,0 +1,110 @@
+package migrations
+
+import "database/sql"
+
+func init() {
+	Register(20, Migration{
+		Name: "fix_opus_4_8_pricing",
+		Up: func(tx *sql.Tx) error {
+			// A claude-opus-4-8 pricing row at the old Opus 4.0/4.1 rates ($15/$75,
+			// 3x the real $5/$25) predated migration 014 on some databases; 014's
+			// INSERT OR IGNORE preserved it, and every opus-4-8 event ingested while
+			// it was active carries a 3x-inflated cost_usd. Correct the row and
+			// recompute the affected events from their stored token counts.
+			//
+			// Value-gated: only a row at exactly the known-bad rates is touched, so
+			// deliberately customized pricing survives — and the event recompute
+			// runs only when the row fix fired, since events priced under custom
+			// rates are consistent with their table and must not be clobbered.
+			res, err := tx.Exec(`
+				UPDATE model_pricing
+				SET input_per_mtok = 5.0, output_per_mtok = 25.0,
+				    cache_read_per_mtok = 0.50, cache_create_per_mtok = 6.25
+				WHERE model_prefix = 'claude-opus-4-8'
+				  AND input_per_mtok = 15.0 AND output_per_mtok = 75.0
+				  AND cache_read_per_mtok = 1.5 AND cache_create_per_mtok = 18.75
+			`)
+			if err != nil {
+				return err
+			}
+			fixed, err := res.RowsAffected()
+			if err != nil {
+				return err
+			}
+			if fixed > 0 {
+				if _, err := tx.Exec(`
+					UPDATE events SET cost_usd =
+						input_tokens*5.0/1e6 + output_tokens*25.0/1e6 +
+						cache_read_tokens*0.50/1e6 + cache_creation_tokens*6.25/1e6
+					WHERE model LIKE 'claude-opus-4-8%'
+				`); err != nil {
+					return err
+				}
+			}
+
+			// Re-sync session aggregates with the events ledger (same recompute as
+			// migration 015). Runs unconditionally: it repairs both the cost change
+			// above and the error_count inflation caused by bootstrap replay
+			// re-incrementing errors after a restart (fixed in the pipeline in this
+			// release; this heals the historical damage). Idempotent.
+			if _, err := tx.Exec(`
+				UPDATE sessions
+				SET total_cost = 0, input_tokens = 0, output_tokens = 0,
+				    cache_read_tokens = 0, cache_creation_tokens = 0
+				WHERE EXISTS (SELECT 1 FROM events e WHERE e.session_id = sessions.id)
+			`); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`
+				UPDATE sessions SET
+					total_cost            = COALESCE(agg.c, 0),
+					input_tokens          = COALESCE(agg.it, 0),
+					output_tokens         = COALESCE(agg.ot, 0),
+					cache_read_tokens     = COALESCE(agg.cr, 0),
+					cache_creation_tokens = COALESCE(agg.cc, 0)
+				FROM (
+					SELECT e.session_id AS sid,
+					       SUM(e.cost_usd)              AS c,
+					       SUM(e.input_tokens)          AS it,
+					       SUM(e.output_tokens)         AS ot,
+					       SUM(e.cache_read_tokens)     AS cr,
+					       SUM(e.cache_creation_tokens) AS cc
+					FROM events e
+					JOIN (
+						SELECT MAX(id) AS mid FROM events
+						WHERE message_id IS NOT NULL AND message_id != ''
+						GROUP BY session_id, message_id
+					) m ON m.mid = e.id
+					GROUP BY e.session_id
+				) AS agg
+				WHERE sessions.id = agg.sid
+			`); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`
+				UPDATE sessions SET error_count = 0
+				WHERE EXISTS (SELECT 1 FROM events e WHERE e.session_id = sessions.id)
+			`); err != nil {
+				return err
+			}
+			if _, err := tx.Exec(`
+				UPDATE sessions SET error_count = COALESCE(ec.n, 0)
+				FROM (
+					SELECT session_id AS sid,
+					       COUNT(DISTINCT COALESCE(NULLIF(message_id,''), uuid)) AS n
+					FROM events WHERE is_error = 1
+					GROUP BY session_id
+				) AS ec
+				WHERE sessions.id = ec.sid
+			`); err != nil {
+				return err
+			}
+			return nil
+		},
+		Down: func(tx *sql.Tx) error {
+			// Corrects bad data to match the events ledger; the prior values were
+			// wrong, so there is no meaningful inverse. No-op, like migration 015.
+			return nil
+		},
+	})
+}

--- a/internal/store/migrations/registry_test.go
+++ b/internal/store/migrations/registry_test.go
@@ -645,3 +645,114 @@ func TestToolResultJoinIndex_UpDown(t *testing.T) {
 		t.Error("idx_events_result_lookup not restored after re-RunUp")
 	}
 }
+
+// TestFixOpus48Pricing_CorrectsBadRowAndRecomputes verifies migration 020:
+// a claude-opus-4-8 pricing row at the known-bad 3x rates ($15/$75) is
+// corrected to $5/$25, affected event costs are recomputed from tokens, and
+// session aggregates (including restart-inflated error_count) are re-synced
+// with the events ledger.
+func TestFixOpus48Pricing_CorrectsBadRowAndRecomputes(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("RunUp: %v", err)
+	}
+	rollDownTo(t, db, "fix_opus_4_8_pricing") // version now 19
+
+	// Recreate the bad state: 3x pricing row, an event costed at the inflated
+	// rate, an error event, and a session row with inflated aggregates
+	// (cost at 3x, error_count doubled by restart replay).
+	mustExec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(q, args...); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+	mustExec(`UPDATE model_pricing SET input_per_mtok=15.0, output_per_mtok=75.0,
+		cache_read_per_mtok=1.5, cache_create_per_mtok=18.75 WHERE model_prefix='claude-opus-4-8'`)
+	mustExec(`INSERT INTO sessions (id, model, total_cost, input_tokens, error_count)
+		VALUES ('s-020', 'claude-opus-4-8', 15.0, 1000000, 2)`)
+	mustExec(`INSERT INTO events (session_id, uuid, message_id, model, cost_usd, input_tokens, timestamp)
+		VALUES ('s-020', 'u1', 'm1', 'claude-opus-4-8', 15.0, 1000000, '2026-06-01T00:00:00Z')`)
+	mustExec(`INSERT INTO events (session_id, uuid, message_id, is_error, timestamp)
+		VALUES ('s-020', 'u2', '', 1, '2026-06-01T00:00:01Z')`)
+
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("re-RunUp: %v", err)
+	}
+
+	var in, out, cr, cc float64
+	if err := db.QueryRow(`SELECT input_per_mtok, output_per_mtok, cache_read_per_mtok,
+		cache_create_per_mtok FROM model_pricing WHERE model_prefix='claude-opus-4-8'`).
+		Scan(&in, &out, &cr, &cc); err != nil {
+		t.Fatalf("pricing row: %v", err)
+	}
+	if in != 5.0 || out != 25.0 || cr != 0.50 || cc != 6.25 {
+		t.Errorf("pricing row = %v/%v/%v/%v, want 5/25/0.5/6.25", in, out, cr, cc)
+	}
+
+	var evCost float64
+	if err := db.QueryRow(`SELECT cost_usd FROM events WHERE message_id='m1'`).Scan(&evCost); err != nil {
+		t.Fatalf("event cost: %v", err)
+	}
+	if evCost != 5.0 {
+		t.Errorf("event cost_usd = %v, want 5.0 (1M input tokens at $5/MTok)", evCost)
+	}
+
+	var sessCost float64
+	var errCount int
+	if err := db.QueryRow(`SELECT total_cost, error_count FROM sessions WHERE id='s-020'`).
+		Scan(&sessCost, &errCount); err != nil {
+		t.Fatalf("session row: %v", err)
+	}
+	if sessCost != 5.0 {
+		t.Errorf("session total_cost = %v, want 5.0", sessCost)
+	}
+	if errCount != 1 {
+		t.Errorf("session error_count = %d, want 1 (doubled count must be recomputed)", errCount)
+	}
+}
+
+// TestFixOpus48Pricing_PreservesCustomPricing verifies migration 020's value
+// gate: a deliberately customized claude-opus-4-8 row (any rates other than
+// the known-bad 15/75) is left untouched and its events are not recomputed.
+func TestFixOpus48Pricing_PreservesCustomPricing(t *testing.T) {
+	db := openTestDB(t)
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("RunUp: %v", err)
+	}
+	rollDownTo(t, db, "fix_opus_4_8_pricing")
+
+	mustExec := func(q string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(q, args...); err != nil {
+			t.Fatalf("exec %q: %v", q, err)
+		}
+	}
+	mustExec(`UPDATE model_pricing SET input_per_mtok=12.0, output_per_mtok=60.0,
+		cache_read_per_mtok=1.2, cache_create_per_mtok=15.0 WHERE model_prefix='claude-opus-4-8'`)
+	mustExec(`INSERT INTO sessions (id, model, total_cost, input_tokens)
+		VALUES ('s-020c', 'claude-opus-4-8', 12.0, 1000000)`)
+	mustExec(`INSERT INTO events (session_id, uuid, message_id, model, cost_usd, input_tokens, timestamp)
+		VALUES ('s-020c', 'u1', 'm1', 'claude-opus-4-8', 12.0, 1000000, '2026-06-01T00:00:00Z')`)
+
+	if _, err := RunUp(db); err != nil {
+		t.Fatalf("re-RunUp: %v", err)
+	}
+
+	var in, out float64
+	if err := db.QueryRow(`SELECT input_per_mtok, output_per_mtok FROM model_pricing
+		WHERE model_prefix='claude-opus-4-8'`).Scan(&in, &out); err != nil {
+		t.Fatalf("pricing row: %v", err)
+	}
+	if in != 12.0 || out != 60.0 {
+		t.Errorf("custom pricing row = %v/%v, want 12/60 untouched", in, out)
+	}
+
+	var evCost float64
+	if err := db.QueryRow(`SELECT cost_usd FROM events WHERE message_id='m1'`).Scan(&evCost); err != nil {
+		t.Fatalf("event cost: %v", err)
+	}
+	if evCost != 12.0 {
+		t.Errorf("event cost_usd = %v, want 12.0 untouched (custom pricing)", evCost)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"sort"
 	"strings"
 	"time"
@@ -567,6 +568,31 @@ func (d *DB) LoadMessageDedup(sessionID string) (map[string]bool, map[string]ses
 		}
 	}
 	return ids, costs, rows.Err()
+}
+
+// LoadErrorDedup returns the distinct stable identities (message_id, else uuid)
+// of a session's persisted error events. Used to rebuild the in-memory "err:"
+// dedup keys after a restart so bootstrap replay does not re-increment
+// error_count for errors already counted — the counterpart of LoadMessageDedup
+// for the error path, matching CountSessionErrors' identity definition.
+func (d *DB) LoadErrorDedup(sessionID string) ([]string, error) {
+	rows, err := d.rdb.Query(`SELECT DISTINCT COALESCE(NULLIF(message_id,''), uuid)
+		FROM events WHERE session_id = ? AND is_error = 1`, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids, rows.Err()
 }
 
 // CountSessionErrors returns the number of distinct error events for a session,
@@ -1308,12 +1334,18 @@ func (d *DB) trendBySession(p *trendParams) ([]SessionTrend, error) {
 	return bySession, nil
 }
 
-// percentile returns the value at the given percentile (0-1) from a sorted slice.
+// percentile returns the value at the given percentile (0-1) from a sorted
+// slice, using the nearest-rank definition: ceil(p*n)-1 (0-indexed). The
+// previous floor(p*n) index was biased one rank high — in a 2-session bucket
+// it reported the maximum as the "median", which 24h trend views hit often.
 func percentile(sorted []float64, p float64) float64 {
 	if len(sorted) == 0 {
 		return 0
 	}
-	idx := int(float64(len(sorted)) * p)
+	idx := int(math.Ceil(float64(len(sorted))*p)) - 1
+	if idx < 0 {
+		idx = 0
+	}
 	if idx >= len(sorted) {
 		idx = len(sorted) - 1
 	}

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -900,14 +900,14 @@ func TestTrendPercentiles(t *testing.T) {
 	}
 
 	b := result.Buckets[0]
-	// Sorted costs: 1,2,3,...,20
-	// Median (index 10): value = 11
-	if b.MedianSessionCost != 11.0 {
-		t.Errorf("median: got %f, want 11.0", b.MedianSessionCost)
+	// Sorted costs: 1,2,3,...,20. Nearest-rank: index ceil(p*20)-1.
+	// Median: ceil(0.5*20)-1 = 9 → value 10
+	if b.MedianSessionCost != 10.0 {
+		t.Errorf("median: got %f, want 10.0", b.MedianSessionCost)
 	}
-	// P95 (index 19): value = 20
-	if b.P95SessionCost != 20.0 {
-		t.Errorf("p95: got %f, want 20.0", b.P95SessionCost)
+	// P95: ceil(0.95*20)-1 = 18 → value 19
+	if b.P95SessionCost != 19.0 {
+		t.Errorf("p95: got %f, want 19.0", b.P95SessionCost)
 	}
 }
 
@@ -1107,9 +1107,10 @@ func TestTrendByModel_CountsChildCostOnce(t *testing.T) {
 }
 
 func TestPercentile(t *testing.T) {
+	// Nearest-rank definition: 0-indexed ceil(p*n)-1.
 	data := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	if got := percentile(data, 0.5); got != 6 {
-		t.Errorf("median of 1-10: got %v, want 6", got)
+	if got := percentile(data, 0.5); got != 5 {
+		t.Errorf("median of 1-10: got %v, want 5 (nearest-rank lower median)", got)
 	}
 	if got := percentile(data, 0.95); got != 10 {
 		t.Errorf("p95 of 1-10: got %v, want 10", got)
@@ -1119,6 +1120,14 @@ func TestPercentile(t *testing.T) {
 	}
 	if got := percentile([]float64{42}, 0.5); got != 42 {
 		t.Errorf("percentile of single element: got %v, want 42", got)
+	}
+	// The motivating regression: a 2-session bucket must not report the
+	// maximum as the median (floor(2*0.5)=1 did exactly that).
+	if got := percentile([]float64{1, 3}, 0.5); got != 1 {
+		t.Errorf("median of {1,3}: got %v, want 1", got)
+	}
+	if got := percentile([]float64{1, 2, 3}, 0.5); got != 2 {
+		t.Errorf("median of {1,2,3}: got %v, want 2", got)
 	}
 }
 


### PR DESCRIPTION
## Audit findings (verified against a production database)

1. **Opus 4.8 costs inflated exactly 3×.** A `claude-opus-4-8` row in `model_pricing` at the old Opus 4.0/4.1 rates ($15/$75 vs the real $5/$25) predated migration 014, whose `INSERT OR IGNORE` preserved it. DB pricing overrides the compiled fallback (which had no opus-4-8 entry at all), so every opus-4-8 event was costed 3× high: **$4,428.47 stored vs $1,476.16 recomputed from stored tokens** — a ~$2,952 lifetime overstatement. All other models matched to the cent.
2. **`error_count` doubles on every restart.** Bootstrap replay re-fires `ErrorCount++` for every historical error line because the `err:` dedup keys were never rebuilt from the DB (cost/token dedup was). Verified live: 497 sessions drifted, 3,494 stored vs 1,748 actual — exactly 2×. Migration 015 fixed the data once; every restart re-broke it.
3. **`percentile()` used `floor(p*n)`** — a 2-session trend bucket reported its maximum as the "median". 24h views hit 2–5-session buckets constantly.
4. Autopsy cosmetics: mixed UTC/local Started/Ended lines, `<local-command-caveat>` junk as the Task line, silent truncation of the error list.

## Fixes

- **parser**: `claude-opus-4-8` added to the compile-time pricing fallback (was falling through to the Sonnet default before the DB row existed).
- **migration 020**: value-gated correction of the known-bad row (custom pricing at any other rates is untouched, and events are only recomputed when the gate fired); then a 015-style re-sync of session cost/token aggregates and `error_count` from the events ledger — healing both bugs' historical damage in one idempotent pass.
- **pipeline**: new `store.LoadErrorDedup` seeds `err:` keys during the restart rebuild. Red-green tested: without the fix the new test reproduces the exact doubling (2 instead of 1).
- **percentile**: nearest-rank `ceil(p*n)-1`, with regression cases for the 2- and 3-element buckets.
- **autopsy**: UTC-normalized timestamps; harness-injected user-role lines (`<local-command-caveat>`, `<command-*>`, `<system-reminder>`…) no longer become `TaskDescription`; "Showing N of M errors" and event-scan truncation notices.

## Testing

- `TestFixOpus48Pricing_CorrectsBadRowAndRecomputes` + `TestFixOpus48Pricing_PreservesCustomPricing` (migration 020, including the value gate).
- `TestProcess_RebuildErrorDedupFromDB` (red-green verified).
- Percentile tests updated to nearest-rank with motivating small-bucket cases.
- Full `go test ./...` passes (one pre-existing flaky server-boot integration test passes on re-run).

## Out of scope (documented audit findings, not regressions)

Session-count semantics differing across /api/stats vs trends, window vocabulary ("today" vs "24h"), cross-session tool-error attribution, CostByModel last-seen-model attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)