### PR TITLE
fix(api): correct OpenAPI spec drift and cover the per-repo 404 contract

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10,10 +10,17 @@ info:
     Routing notes: every route is registered for a single HTTP method, so a
     request to an existing path with an unsupported method returns
     `405 Method Not Allowed` (with an `Allow` header) rather than 404. The
-    per-repo endpoints (`/api/repos/{id}/stats`, `/api/repos/{id}/sessions`) do
-    not 404 for an unknown repo id — they return a `200` with zeroed aggregates
-    or an empty array respectively.
-  version: "3.5.1"
+    per-repo endpoints (`/api/repos/{id}/stats`, `/api/repos/{id}/sessions`)
+    return `404 {"error":"repo not found"}` for a repo id that is not present in
+    the database.
+
+
+    Repo ids are canonical repository paths that contain `/` (for example
+    `github.com/owner/name`), so they MUST be percent-encoded when interpolated
+    into a path — `/api/repos/github.com%2Fowner%2Fname/stats`. An unencoded id
+    spans multiple path segments and does not match the route, yielding a plain
+    `404 page not found`.
+  version: "3.8.3" # x-release-please-version
 
 servers:
   - url: http://localhost:7700
@@ -104,7 +111,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/VersionResponse"
               example:
-                version: "3.5.1"
+                version: "3.8.3" # x-release-please-version
 
   /api/sessions:
     get:
@@ -362,6 +369,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StatsResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -400,6 +409,69 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /api/stats/tools:
+    get:
+      tags: [stats]
+      summary: Tool and skill invocation breakdown
+      description: >
+        Returns per-tool and per-skill invocation counts with the number of
+        invocations whose `tool_result` reported an error, for sessions that
+        started within the window.
+
+
+        `tools` is grouped by tool name and excludes the `Skill` tool itself;
+        `skills` is the `Skill` tool's invocations grouped by the skill that was
+        invoked. Both lists are ordered by `uses` descending and each is capped
+        at 50 entries, so a long tail of rarely-used tools is not returned.
+      operationId: getToolUsage
+      parameters:
+        - name: window
+          in: query
+          description: >
+            Rolling time window for the breakdown. `all` (or omitted) aggregates
+            over all history. Note this endpoint accepts only the rolling
+            vocabulary — the calendar tokens (`today`/`week`/`month`) are not
+            valid here.
+          schema:
+            type: string
+            enum: [all, 24h, 7d, 30d]
+            default: all
+        - name: repo
+          in: query
+          description: Optional repository ID to filter the breakdown to a single repo.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Tool and skill usage breakdown
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ToolUsageResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
+  /api/skills/sessions:
+    get:
+      tags: [stats]
+      summary: Skills invoked per session
+      description: >
+        Returns a sparse map of session ID to the skills that session invoked,
+        with per-skill use and error counts. Only sessions that invoked at least
+        one skill appear as keys. Used to badge rows in the history view.
+      operationId: getSessionSkills
+      responses:
+        "200":
+          description: Map of session ID to that session's skill invocations
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SessionSkills"
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /api/repos:
     get:
       tags: [repos]
@@ -435,6 +507,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AggregateResult"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -470,6 +544,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Session"
+        "404":
+          $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalError"
 
@@ -505,9 +581,12 @@ paths:
       parameters:
         - name: q
           in: query
-          required: true
+          required: false
           description: >
-            Free-text search query. Each whitespace-separated word is matched as a
+            Free-text search query. Omitted or blank returns an empty array
+            rather than an error.
+
+            Each whitespace-separated word is matched as a
             quoted literal term and the terms are combined with implicit AND, so a
             multi-word query matches documents containing all of the words anywhere
             (not necessarily adjacent). FTS5 operators (AND/OR/NEAR, column filters,
@@ -547,8 +626,10 @@ paths:
       parameters:
         - name: q
           in: query
-          required: true
-          description: Search query string (substring match on full content).
+          required: false
+          description: >
+            Search query string (substring match on full content). Omitted or
+            blank returns an empty array rather than an error.
           schema:
             type: string
         - name: limit
@@ -590,9 +671,12 @@ paths:
       parameters:
         - name: q
           in: query
-          required: true
+          required: false
           description: >
-            Free-text search query. The FTS5 leg matches each whitespace-separated
+            Free-text search query. Omitted or blank returns an empty result
+            rather than an error.
+
+            The FTS5 leg matches each whitespace-separated
             word as a quoted literal term combined with implicit AND (words may
             appear anywhere, not necessarily adjacent); FTS5 operators are not
             interpreted. The full-content leg performs a substring match.
@@ -848,9 +932,15 @@ components:
       name: id
       in: path
       required: true
-      description: Repository ID (SHA256 hash of the repo root path).
+      description: >
+        Repository ID as returned in the `id` field of `GET /api/repos` — a
+        canonical repository path such as `github.com/owner/name`. Because it
+        contains `/`, it MUST be percent-encoded here
+        (`github.com%2Fowner%2Fname`); an unencoded id spans multiple path
+        segments, fails to match the route and returns `404 page not found`.
       schema:
         type: string
+      example: github.com%2Fowner%2Fname
 
   responses:
     NotFound:
@@ -897,7 +987,7 @@ components:
         version:
           type: string
           description: Build version string (set via ldflags at compile time).
-          example: "3.5.1"
+          example: "3.8.3" # x-release-please-version
 
     Session:
       type: object
@@ -1552,7 +1642,7 @@ components:
     TrendResult:
       type: object
       description: Complete trend analysis response with time buckets and breakdowns.
-      required: [window, buckets, byRepo, byModel, summary]
+      required: [window, buckets, byRepo, byModel, bySession, summary]
       properties:
         window:
           type: string
@@ -1576,6 +1666,14 @@ components:
           description: Cost and token breakdown per model.
           items:
             $ref: "#/components/schemas/ModelTrend"
+        bySession:
+          type: array
+          description: >
+            Cost and token breakdown per top-level session. Unlike byRepo, a
+            session's spend stays intact here even when the run touched
+            directories belonging to several repositories.
+          items:
+            $ref: "#/components/schemas/SessionTrend"
         summary:
           $ref: "#/components/schemas/TrendSummary"
 
@@ -1715,6 +1813,90 @@ components:
           type: integer
           description: Number of sessions using this model in the window.
           example: 30
+
+    ToolUsageEntry:
+      type: object
+      description: One tool or skill with its invocation and error counts.
+      required: [name, uses, errors]
+      properties:
+        name:
+          type: string
+          description: Tool name (e.g. `Bash`) or skill name (e.g. `commit`).
+          example: "Bash"
+        uses:
+          type: integer
+          description: Number of `tool_use` invocations.
+          example: 1736
+        errors:
+          type: integer
+          description: Invocations whose `tool_result` reported an error.
+          example: 63
+    ToolUsageResult:
+      type: object
+      description: Tool and skill usage breakdown for a window/repo scope.
+      required: [tools, skills]
+      properties:
+        tools:
+          type: array
+          description: >
+            Invocations grouped by tool name, excluding the `Skill` tool.
+            Ordered by `uses` descending, capped at 50 entries.
+          items:
+            $ref: "#/components/schemas/ToolUsageEntry"
+        skills:
+          type: array
+          description: >
+            The `Skill` tool's invocations grouped by the invoked skill name.
+            Ordered by `uses` descending, capped at 50 entries.
+          items:
+            $ref: "#/components/schemas/ToolUsageEntry"
+    SessionSkills:
+      type: object
+      description: >
+        Sparse map of session ID to the skills that session invoked. Sessions
+        that invoked no skills are absent rather than present with an empty
+        array.
+      additionalProperties:
+        type: array
+        items:
+          $ref: "#/components/schemas/ToolUsageEntry"
+      example:
+        550e8400-e29b-41d4-a716-446655440000:
+          - name: commit
+            uses: 2
+            errors: 0
+
+    SessionTrend:
+      type: object
+      description: >
+        Cost and token breakdown for a single top-level session within a trend
+        window, with its workflow/subagent descendants rolled up into it.
+      required: [sessionId, sessionName, cost, tokens, agents]
+      properties:
+        sessionId:
+          type: string
+          description: ID of the top-level session.
+          example: "550e8400-e29b-41d4-a716-446655440000"
+        sessionName:
+          type: string
+          description: Display name for the session.
+          example: "claude-monitor"
+        cost:
+          type: number
+          format: double
+          description: Total cost for this session in the window, including its agents.
+          example: 12.44
+        tokens:
+          type: integer
+          format: int64
+          description: Total tokens consumed by this session in the window, including its agents.
+          example: 2400000
+        agents:
+          type: integer
+          description: >
+            Number of session rows rolled up into this entry (the top-level
+            session plus its workflow/subagent descendants).
+          example: 4
 
     TrendSummary:
       type: object

--- a/cmd/claude-monitor/main_test.go
+++ b/cmd/claude-monitor/main_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -561,5 +562,81 @@ func TestSessionReplay(t *testing.T) {
 	}
 	if body.Events == nil {
 		t.Error("events should be non-nil array")
+	}
+}
+
+// TestRepoEndpointsUnknownIDReturn404 pins the documented contract that the
+// per-repo endpoints reject an unknown repo id rather than reporting zeroed
+// aggregates or an empty list, which would be indistinguishable from a real
+// repo that happens to have no recorded activity.
+func TestRepoEndpointsUnknownIDReturn404(t *testing.T) {
+	t.Parallel()
+
+	for _, path := range []string{
+		"/api/repos/no-such-repo/stats",
+		"/api/repos/no-such-repo/sessions",
+	} {
+		resp, err := http.Get(baseURL + path)
+		if err != nil {
+			t.Fatalf("GET %s failed: %v", path, err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s: status = %d, want 404", path, resp.StatusCode)
+			continue
+		}
+
+		var body struct {
+			Error string `json:"error"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Errorf("GET %s: failed to decode error body: %v", path, err)
+			continue
+		}
+		if body.Error != "repo not found" {
+			t.Errorf("GET %s: error = %q, want %q", path, body.Error, "repo not found")
+		}
+	}
+}
+
+// TestRepoStatsRequiresEncodedID pins the encoding requirement for repo ids.
+// Ids are canonical repository paths containing "/", so an unencoded id spans
+// several path segments and cannot match the single-segment {id} wildcard; only
+// the percent-encoded form reaches the handler. Callers that interpolate the raw
+// id from /api/repos get a 404, so the contract is worth locking down.
+func TestRepoStatsRequiresEncodedID(t *testing.T) {
+	t.Parallel()
+
+	var repos []struct {
+		ID string `json:"id"`
+	}
+	getJSON(t, "/api/repos", &repos)
+
+	var id string
+	for _, r := range repos {
+		if strings.Contains(r.ID, "/") {
+			id = r.ID
+			break
+		}
+	}
+	if id == "" {
+		t.Skip("no repo with a slash-bearing id in the database")
+	}
+
+	resp, err := http.Get(baseURL + "/api/repos/" + id + "/stats")
+	if err != nil {
+		t.Fatalf("GET unencoded repo stats failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("unencoded id %q: status = %d, want 404", id, resp.StatusCode)
+	}
+
+	var agg map[string]interface{}
+	getJSON(t, "/api/repos/"+url.PathEscape(id)+"/stats", &agg)
+	if _, ok := agg["totalCost"]; !ok {
+		t.Errorf("encoded id %q: response missing totalCost, got keys %v",
+			url.PathEscape(id), agg)
 	}
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,8 @@
     ".": {
       "release-type": "go",
       "bump-minor-pre-major": false,
-      "bump-patch-for-minor-pre-major": false
+      "bump-patch-for-minor-pre-major": false,
+      "extra-files": ["api/openapi.yaml"]
     }
   }
 }


### PR DESCRIPTION
Validated the running API against `api/openapi.yaml` operation by operation — **33 operations**, checked in both directions (response violates the declared schema, *and* response contains fields the schema does not document), against a snapshot of a real 501MB database.

**Every endpoint behaves correctly.** The WebSocket upgrade, the settings allowlist and its per-key validation, pricing upsert persistence, and the `405` + `Allow` method guard all hold. What was wrong was the document. Eight defects, **no server behaviour changes**.

## Findings

| # | Defect | Consequence |
|---|---|---|
| 1 | `info.version` pinned at `3.5.1`, binary reports `3.8.3` | Spec misidentifies itself |
| 2 | Routing note promises `200` for unknown repo id; handler returns `404` | Spec contradicts implementation |
| 3 | `RepoId` described as "SHA256 hash of the repo root path" | Following the spec yields `404 page not found` |
| 4 | `q` marked `required: true` on all 3 search endpoints | Contradicts documented + actual optional behaviour |
| 5 | `TrendResult.bySession` returned but unschema'd | Generated clients drop the field |
| 6 | `/api/stats/tools` undocumented | Live, frontend-consumed, invisible to API consumers |
| 7 | `/api/skills/sessions` undocumented | Same |
| 8 | `/api/stats` returns `400` but declares only `200`/`500` | Undocumented failure mode |

## Notes on the interesting ones

**#1 — fixed so it cannot recur.** Rather than hand-patching the version a third time, the three version literals now carry `x-release-please-version` annotations and `api/openapi.yaml` is registered in `release-please-config.json` `extra-files`. Releases keep it in step from here.

**#2 — this one has history.** The note claimed the per-repo endpoints *"do not 404 for an unknown repo id — they return a `200` with zeroed aggregates or an empty array respectively"*. They return `404 {"error":"repo not found"}`, and deliberately so: `e9af5e5` made that change on purpose. That commit's own message says it documented the repo 404 — but it only replaced part of the text, so the contradicting paragraph survived and neither operation ever declared a `404` response. The handler is right; the note is now corrected and both `404`s are declared.

**#3 — the spec was actively misleading.** Repo ids are canonical repository paths like `github.com/owner/name`. Because they contain `/`, they must be percent-encoded to match the single-segment `{id}` wildcard:

```
/api/repos/github.com/Zxela/claude-monitor/stats      -> 404 page not found
/api/repos/github.com%2FZxela%2Fclaude-monitor/stats  -> 200
```

A caller reading the old description would send a SHA256 hash — or interpolate the raw `id` straight from `/api/repos` — and get a 404 either way. The requirement is now stated on the parameter and in the routing note. The frontend never hit this because `web/src/api.ts` only calls `/api/repos`; these two endpoints are public API surface with no in-tree consumer, which is exactly why the docs needed to be right.

## Tests

No case covered the per-repo 404, so a regression would have been silent:

- `TestRepoEndpointsUnknownIDReturn404` — pins the status and the `repo not found` error body on both endpoints.
- `TestRepoStatsRequiresEncodedID` — pins that the raw id 404s while the percent-encoded form returns aggregates; skips when the database holds no slash-bearing repo id.

`go test ./...` green. After these changes the spec validator reports **0 errors, 0 drift** across all 33 operations; run against the pre-fix spec it still reports 12 errors and 10 drift, so it is discriminating rather than permissive.

> [!NOTE]
> Independent of this PR: #256 also edits `api/openapi.yaml` (window enums, `agentCount`), so whichever merges second will need a small conflict resolution in `TrendResult` and the `/api/stats` parameter block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)