### PR TITLE
fix(web): define the missing type scale and stop views stacking in the shared mount

### DIFF
--- a/web/src/components/analytics-view.ts
+++ b/web/src/components/analytics-view.ts
@@ -70,11 +70,15 @@ function onStateChange(_state: AppState, changed: Set<string>): void {
 function show(): void {
   if (!container) return;
 
-  // Remove any existing root
-  if (root) {
-    root.remove();
-    root = null;
-  }
+  // Take over the shared #feed-mount. The graph, feed, timeline and history
+  // views leave their DOM behind when navigated away from — they rely on the
+  // next full-clear render to wipe the mount. Clear it here so a stale
+  // full-height sibling (e.g. the graph container) cannot sit above us and push
+  // the analytics view below the fold. destroyCards() runs first so Chart.js
+  // instances on canvases we are about to detach are torn down, not leaked.
+  destroyCards();
+  container.innerHTML = '';
+  root = null;
 
   root = document.createElement('div');
   root.className = 'analytics-view';

--- a/web/src/components/session-card.ts
+++ b/web/src/components/session-card.ts
@@ -207,7 +207,7 @@ export function renderCompact(
       ${session.costRate > 0 ? `<span class="cost-rate">$${session.costRate.toFixed(3)}/min</span>` : ''}
       <span class="duration">${timeAgo(session.lastActive)}</span>
       <span class="duration">${formatDuration(session.startedAt, session.lastActive)}</span>
-      ${session.errorCount > 0 ? `<span class="compact-stat-err">${session.errorCount} err</span>` : ''}
+      ${session.errorCount > 0 ? `<span class="session-error-count">${session.errorCount} err</span>` : ''}
     </div>
   `;
 
@@ -228,11 +228,10 @@ export function renderCompact(
   });
 
   // Error count click — filter feed to errors only
-  const errEl = el.querySelector('.compact-stat-err');
+  const errEl = el.querySelector('.session-error-count');
   if (errEl) {
     errEl.setAttribute('role', 'button');
     errEl.setAttribute('tabindex', '0');
-    (errEl as HTMLElement).style.cursor = 'pointer';
     const filterErrors = (e: Event) => {
       e.stopPropagation();
       update({

--- a/web/src/components/table-view.ts
+++ b/web/src/components/table-view.ts
@@ -119,13 +119,23 @@ function renderTable(): void {
     return;
   }
 
-  // Recreate the node if it was detached: the feed panel wipes #feed-mount when
-  // other views render into it, leaving a stale tableEl whose parentElement is no
-  // longer `container`. Without this guard the table stays permanently blank
-  // after navigating away and back.
-  if (!tableEl || tableEl.parentElement !== container) {
+  if (!tableEl) {
     tableEl = document.createElement('div');
     tableEl.className = 'table-view';
+  }
+  // Take over the shared #feed-mount. Two cases are handled together:
+  //   - tableEl was detached, because the feed panel wipes #feed-mount when it
+  //     renders (without this the table stays permanently blank after
+  //     navigating away and back);
+  //   - the mount still holds another view's DOM, because graph/feed/timeline/
+  //     history leave theirs behind on exit. A stale full-height sibling would
+  //     otherwise sit above the table and push it below the fold.
+  // Clearing makes the table the sole occupant. No-op once it already is.
+  if (
+    tableEl.parentElement !== container ||
+    container.childElementCount !== 1
+  ) {
+    container.innerHTML = '';
     container.appendChild(tableEl);
   }
 

--- a/web/src/components/table-view.ts
+++ b/web/src/components/table-view.ts
@@ -156,7 +156,7 @@ function renderTable(): void {
   const headerCells = cols
     .map(
       (c) =>
-        `<th data-sort="${c.key}" style="text-align:${c.align ?? 'left'};cursor:pointer;user-select:none;padding:6px 10px;border-bottom:1px solid var(--border);color:var(--text-dim);font-size:10px;letter-spacing:0.5px;white-space:nowrap">
+        `<th data-sort="${c.key}" style="text-align:${c.align ?? 'left'};cursor:pointer;user-select:none;padding:6px 10px;border-bottom:1px solid var(--border);color:var(--text-dim);font-size:var(--fs-base);font-weight:var(--fw-bold);letter-spacing:var(--tracking-label);white-space:nowrap">
           ${c.label} ${arrowFor(c.key)}
         </th>`,
     )
@@ -185,25 +185,25 @@ function renderTable(): void {
       const isSelected = state.selectedSessionId === s.id;
 
       return `<tr data-session-id="${s.id}" style="cursor:pointer;background:${isSelected ? 'var(--bg-hover)' : 'transparent'};border-left:${isSelected ? '2px solid var(--cyan)' : '2px solid transparent'}">
-        <td style="padding:5px 10px;font-size:11px;max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${name}">${name}</td>
-        <td style="padding:5px 10px;font-size:10px;color:${statusColor}">${statusLabel}</td>
-        <td style="padding:5px 10px;font-size:11px;text-align:right;color:${s.totalCost > 0.1 ? 'var(--yellow)' : 'var(--text)'}">$${s.totalCost.toFixed(4)}</td>
-        <td style="padding:5px 10px;font-size:11px;text-align:right;color:var(--text-dim)">${totalTokens.toLocaleString()}</td>
-        <td style="padding:5px 10px;font-size:11px;text-align:right">${s.messageCount}</td>
-        <td style="padding:5px 10px;font-size:11px;text-align:right;color:${s.errorCount > 0 ? 'var(--red)' : 'var(--text-dim)'}">${s.errorCount || '—'}</td>
-        <td style="padding:5px 10px;font-size:11px;text-align:right;color:var(--text-dim)">${duration}</td>
-        <td style="padding:5px 10px;font-size:11px;text-align:right;color:var(--text-dim)">${lastActive}</td>
+        <td style="padding:5px 10px;font-size:var(--fs-lg);font-weight:var(--fw-medium);max-width:200px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${name}">${name}</td>
+        <td style="padding:5px 10px;font-size:var(--fs-sm);color:${statusColor}">${statusLabel}</td>
+        <td style="padding:5px 10px;font-size:var(--fs-base);font-weight:var(--fw-medium);text-align:right;color:${s.totalCost > 0.1 ? 'var(--yellow)' : 'var(--text)'}">$${s.totalCost.toFixed(4)}</td>
+        <td style="padding:5px 10px;font-size:var(--fs-base);text-align:right;color:var(--text-dim)">${totalTokens.toLocaleString()}</td>
+        <td style="padding:5px 10px;font-size:var(--fs-base);text-align:right">${s.messageCount}</td>
+        <td style="padding:5px 10px;font-size:var(--fs-base);text-align:right;color:${s.errorCount > 0 ? 'var(--red)' : 'var(--text-dim)'}">${s.errorCount || '—'}</td>
+        <td style="padding:5px 10px;font-size:var(--fs-base);text-align:right;color:var(--text-dim)">${duration}</td>
+        <td style="padding:5px 10px;font-size:var(--fs-base);text-align:right;color:var(--text-dim)">${lastActive}</td>
       </tr>`;
     })
     .join('');
 
   tableEl.innerHTML = `
     <div style="display:flex;align-items:center;justify-content:space-between;padding:8px 10px;border-bottom:1px solid var(--border)">
-      <span style="color:var(--cyan);font-size:11px;letter-spacing:1px">TABLE VIEW</span>
-      <span style="color:var(--text-dim);font-size:10px">${sessions.length} session${sessions.length !== 1 ? 's' : ''}</span>
+      <span style="color:var(--cyan);font-size:var(--fs-base);letter-spacing:var(--tracking-label)">TABLE VIEW</span>
+      <span style="color:var(--text-dim);font-size:var(--fs-sm)">${sessions.length} session${sessions.length !== 1 ? 's' : ''}</span>
     </div>
     <div style="overflow:auto;flex:1">
-      <table style="width:100%;border-collapse:collapse;font-family:var(--font-mono,monospace)">
+      <table style="width:100%;border-collapse:collapse;font-family:var(--font-mono)">
         <thead>
           <tr>${headerCells}</tr>
         </thead>

--- a/web/src/styles/base.css
+++ b/web/src/styles/base.css
@@ -12,6 +12,33 @@
   --purple: #bc8cff;
   --orange: #f0883e;
   --font-mono: "JetBrains Mono", "Consolas", "Monaco", monospace;
+  --font-sans:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  /* Type scale — collapse the ad-hoc px ladder into a deliberate set of steps.
+     Values match the px literals already in use so adoption is near-zero visual change. */
+  --fs-xs: 9px; /* badges, chevrons, micro labels */
+  --fs-sm: 10px; /* meta rows, timestamps, durations */
+  --fs-base: 11px; /* default UI text / data cells */
+  --fs-md: 12px; /* reading/content tier */
+  --fs-lg: 13px; /* titles, subheadings, emphasis */
+  --fs-xl: 18px; /* large numeric values */
+  --fs-display: 24px; /* hero stat value */
+  --fs-icon: 16px; /* icon / close glyph buttons */
+  /* Compatibility aliases for the legacy --text-* names used across the app
+     (previously referenced but never defined → silently broken). */
+  --text-xs: var(--fs-xs);
+  --text-sm: var(--fs-sm);
+  --text-base: var(--fs-base);
+  --text-md: var(--fs-md);
+  --text-lg: var(--fs-lg);
+  /* Weight scale — use these instead of raw numbers or the `bold` keyword. */
+  --fw-normal: 400;
+  --fw-medium: 600;
+  --fw-bold: 700;
+  /* Tracking + leading */
+  --tracking-label: 1px; /* caps-style labels / column headers */
+  --tracking-wide: 2px; /* brand wordmark */
+  --lh-body: 1.5; /* multi-line body content */
   --color-user: #5588ff;
   --color-assistant: #33dd99;
   --color-tool-use: #ddcc44;

--- a/web/src/styles/sessions.css
+++ b/web/src/styles/sessions.css
@@ -24,7 +24,7 @@
   border: 1px solid var(--border);
   color: var(--text-dim);
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: var(--fs-base);
   padding: 4px 0;
   cursor: pointer;
 }
@@ -53,10 +53,10 @@
 
 .active-section-header {
   padding: 6px 4px 2px;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
   color: var(--green);
-  letter-spacing: 1px;
+  letter-spacing: var(--tracking-label);
 }
 
 /* Time group headers */
@@ -65,13 +65,13 @@
   align-items: center;
   justify-content: space-between;
   padding: 5px 10px 3px;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-bold);
   color: var(--text-dim);
   cursor: pointer;
   user-select: none;
   border-bottom: 1px solid var(--border);
-  letter-spacing: 1px;
+  letter-spacing: var(--tracking-label);
 }
 
 .time-group-header:hover {
@@ -82,7 +82,7 @@
   background: var(--border);
   border-radius: 8px;
   padding: 1px 6px;
-  font-size: 10px;
+  font-size: var(--fs-sm);
 }
 
 .time-group-collapsed .time-group-items {
@@ -91,10 +91,10 @@
 
 .time-group-empty {
   padding: 24px 12px;
-  font-size: 10px;
-  font-weight: 600;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
   color: var(--text-dim);
-  letter-spacing: 1px;
+  letter-spacing: var(--tracking-label);
   text-align: center;
   opacity: 0.4;
 }
@@ -103,14 +103,14 @@
   display: block;
   width: 100%;
   padding: 4px 12px;
-  font-size: 9px;
+  font-size: var(--fs-xs);
   color: var(--cyan);
   cursor: pointer;
   background: none;
   border: none;
   font-family: var(--font-mono);
   text-align: left;
-  letter-spacing: 0.5px;
+  letter-spacing: var(--tracking-label);
   opacity: 0.7;
 }
 
@@ -227,8 +227,8 @@
 
 .session-card .session-name {
   flex: 1;
-  font-weight: 600;
-  font-size: var(--text-lg);
+  font-weight: var(--fw-medium);
+  font-size: var(--fs-lg);
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -240,7 +240,7 @@
 .subagent-chevron {
   color: var(--purple);
   opacity: 0.8;
-  font-size: 9px;
+  font-size: var(--fs-xs);
   cursor: pointer;
   flex-shrink: 0;
   margin-left: auto;
@@ -254,9 +254,9 @@
 /* Status badge */
 .session-status-badge {
   display: inline-block;
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 1px;
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--tracking-label);
   padding: 1px 5px;
   border-radius: 2px;
   text-transform: uppercase;
@@ -298,7 +298,7 @@
 
 /* Task description */
 .session-task-desc {
-  font-size: 11px;
+  font-size: var(--fs-base);
   color: var(--text-dim);
   margin-top: 2px;
   overflow: hidden;
@@ -311,7 +311,7 @@
   display: flex;
   gap: 8px;
   margin-top: 3px;
-  font-size: var(--text-base);
+  font-size: var(--fs-base);
   color: var(--text-dim);
   flex-wrap: wrap;
   align-items: center;
@@ -319,11 +319,11 @@
 
 .session-stats .cost {
   color: var(--yellow);
-  font-weight: 600;
+  font-weight: var(--fw-medium);
 }
 .session-stats .cost-rate {
   color: var(--text-dim);
-  font-size: 9px;
+  font-size: var(--fs-xs);
   opacity: 0.6;
 }
 .session-stats .tok {
@@ -332,13 +332,15 @@
 .session-stats .cache {
   color: var(--purple);
 }
-.session-stats .session-error-count {
+/* Shared by both expanded and compact cards (see .compact-stat-err removal). */
+.session-error-count {
   color: var(--red);
-  font-weight: 600;
-  font-size: 10px;
+  font-weight: var(--fw-medium);
+  font-size: var(--fs-sm);
   text-decoration: underline;
   text-decoration-style: dotted;
   text-underline-offset: 2px;
+  cursor: pointer;
 }
 
 /* Meta row */
@@ -346,7 +348,7 @@
   display: flex;
   gap: 8px;
   margin-top: 2px;
-  font-size: var(--text-sm);
+  font-size: var(--fs-sm);
   color: #44445a;
 }
 
@@ -357,7 +359,7 @@
   display: flex;
   flex-direction: column;
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--fs-md);
   transition:
     border-color 0.2s,
     background 0.2s;
@@ -411,6 +413,9 @@
 
 .session-card-compact .session-name {
   flex: 1;
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-medium);
+  color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -419,33 +424,29 @@
 
 .session-card-compact .cost {
   color: var(--yellow);
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--fs-base);
+  font-weight: var(--fw-medium);
 }
 .session-card-compact .cost-rate {
   color: var(--text-dim);
-  font-size: 9px;
+  font-size: var(--fs-xs);
   opacity: 0.6;
 }
 .session-card-compact .duration {
   color: #44445a;
-  font-size: 10px;
+  font-size: var(--fs-sm);
 }
 .session-card-compact .model {
-  font-size: 9px;
+  font-size: var(--fs-base);
   color: var(--text-dim);
   background: var(--border);
   padding: 1px 4px;
   border-radius: 2px;
 }
 
-.session-card-compact .subagent-chevron {
-  font-size: 9px;
-}
-
 .compact-task-desc {
   padding: 0 0 1px 13px;
-  font-size: 10px;
+  font-size: var(--fs-sm);
   color: var(--text-dim, #888);
   white-space: nowrap;
   overflow: hidden;
@@ -456,31 +457,27 @@
   display: flex;
   gap: 8px;
   padding: 1px 0 0 13px;
-  font-size: 10px;
+  font-size: var(--fs-sm);
   color: var(--text-dim, #666);
   align-items: center;
 }
 
-.compact-stat-err {
-  color: var(--red, #ff4444);
-  font-size: 9px;
-}
-
 .session-card-compact .session-status-badge {
-  font-size: 8px;
+  font-size: var(--fs-xs);
   padding: 0 4px;
-  line-height: 14px;
+  display: inline-flex;
+  align-items: center;
 }
 
 /* Idle subagent toggle */
 .idle-toggle {
   margin-left: 20px;
   padding: 3px 8px;
-  font-size: 9px;
+  font-size: var(--fs-xs);
   color: var(--text-dim);
   cursor: pointer;
   opacity: 0.5;
-  letter-spacing: 0.5px;
+  letter-spacing: var(--tracking-label);
   background: none;
   border: none;
   font-family: var(--font-mono);
@@ -501,7 +498,7 @@
 }
 
 .session-current-tool {
-  font-size: 10px;
+  font-size: var(--fs-sm);
   color: var(--text-dim);
   opacity: 0.7;
   overflow: hidden;
@@ -613,7 +610,7 @@
   border-top: 1px solid var(--border);
   color: var(--text-dim);
   font-family: var(--font-mono);
-  font-size: 14px;
+  font-size: var(--fs-icon);
   cursor: pointer;
   text-align: center;
   margin-top: auto;

--- a/web/src/styles/views.css
+++ b/web/src/styles/views.css
@@ -102,12 +102,12 @@
 .view-overlay table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 12px;
+  font-size: var(--fs-md);
 }
 
 .view-overlay th {
-  font-size: 11px;
-  font-weight: 700;
+  font-size: var(--fs-base);
+  font-weight: var(--fw-bold);
   text-transform: uppercase;
   color: var(--text-dim);
   padding: 8px 10px;
@@ -127,7 +127,7 @@
 
 .sort-arrow {
   margin-left: 4px;
-  font-size: 9px;
+  font-size: var(--fs-xs);
 }
 
 .view-overlay td {
@@ -146,6 +146,9 @@
   max-width: none;
   white-space: normal;
   overflow: visible;
+  font-size: var(--fs-lg);
+  font-weight: var(--fw-medium);
+  color: var(--text);
 }
 
 .view-overlay tr:hover {
@@ -157,6 +160,8 @@
 
 .view-overlay .col-cost {
   color: var(--yellow);
+  font-size: var(--fs-base);
+  font-weight: var(--fw-medium);
 }
 .view-overlay .col-rate {
   color: var(--yellow);
@@ -172,7 +177,7 @@
 }
 .view-overlay .col-model {
   color: var(--text-dim);
-  font-size: 11px;
+  font-size: var(--fs-base);
 }
 .view-overlay .col-dim {
   color: var(--text-dim);

--- a/web/src/styles/views.css
+++ b/web/src/styles/views.css
@@ -453,7 +453,10 @@
 
 /* Sequence view */
 .sequence-list {
-  padding: 8px 0;
+  /* Top padding clears the absolutely-positioned .graph-mode-toggle (top: 8px,
+     ~20px tall) so the first row's right-aligned cost/status isn't hidden
+     beneath it. */
+  padding: 40px 0 8px;
   overflow-y: auto;
   height: 100%;
 }


### PR DESCRIPTION
Recovers the two surviving UI fixes from stale local branches (`fix/font-consistency-and-hooks`, `worktree-fix-nav`) that never had PRs. **Both bugs were re-verified as live in the shipped 3.8.4 build before landing anything** — the point of this PR was validation, not just rebasing.

A third branch, `fix/workflow-session-attribution`, was **discarded** rather than landed. See the bottom.

## 1. The type scale was referenced but never defined

`--text-*` size tokens are used across the stylesheets and **were never declared**, so they silently resolved to nothing and every affected element fell back to an inherited or literal size. Measured on main:

| Token | Usages | Defined? |
|---|---|---|
| `--text-base` | 3 | ❌ |
| `--text-md` | 1 | ❌ |
| `--text-lg` | 1 | ❌ |
| `--text-sm` | 1 | ❌ |

Confirmed against the running 3.8.4 build, not just the source — `getComputedStyle(:root).getPropertyValue('--text-lg')` returned empty. `--text-dim` *is* defined, which is what made this easy to miss: it's a colour, and its presence made the family look intentional.

This adds a real scale in `:root` (`--fs-*`, `--fw-*`, `--tracking-*`, `--lh-*`, a `--font-sans` token, and `--text-*` aliases for the legacy names) and migrates the two surfaces where the inconsistency was visible — session cards and the history/table rows, which rendered the same datum at different sizes. Values match the px literals already in use, so adoption is near-zero visual change; the one deliberate difference is the previously-broken `--text-lg` session name resolving to 13px.

After: all four tokens resolve (`10px`/`11px`/`12px`/`13px`).

## 2. Views stacked in the shared `#feed-mount`

`analytics-view` and `table-view` appended into the shared mount without clearing it, while graph/feed/timeline/history leave their DOM behind on exit — they rely on the next clear-on-show view to wipe it. So graph → analytics left the full-height graph in place and appended analytics underneath.

Reproduced on main in a browser:

```
after graph:      [ .graph-container  h=1161  y=36 ]
after analytics:  [ .graph-container  h=1161  y=36 ]
                  [ .analytics-view            y=1197 ]   ← 1223px viewport
```

26px of the analytics view on screen — it read as "didn't render". Same cause for graph → table.

Both views now clear the mount on takeover, becoming its sole occupant. `analytics-view` calls `destroyCards()` first so Chart.js instances on canvases about to be detached are torn down rather than leaked. In `table-view` this **replaces** the narrower recreate-if-detached guard: node creation and mount adoption are now separate concerns, and adoption also fires when the mount holds a *foreign* child, not only when `tableEl` itself was detached.

Also bumps `.sequence-list` top padding 8px → 40px: `.graph-mode-toggle` is `position: absolute; top: 8px` and ~20px tall, so it sat on top of the first row's right-aligned cost/status.

After, measured in-browser:

```
graph → analytics:  1 child, .analytics-view  y=36
graph → table:      1 child, .table-view      y=36
.sequence-list:     padding-top 40px
toggle bottom 65px  <  first row top 76px      ✓ clears
```

## Regression check

Clearing the shared mount is exactly the kind of change that blanks an unrelated view, so I swept **11 transitions** across list / graph / analytics / history / table including back-and-forth pairs. Every step rendered non-empty content and every view was the mount's sole occupant. No blanks.

`npm run build`, `format:check`, `lint`, `tsc --noEmit`, `typecheck:test` and all 45 tests pass.

## What I dropped, and why

Only the **semantic** hunks were taken from the original commits. Both also reflowed these files under the pre-Biome 100-column Prettier config, which would have fought the formatter now gated in CI. Cherry-picking them wholesale produced conflicts that were entirely quote-style and line-wrapping noise.

`fix/font-consistency-and-hooks` also carried the `lefthook.yml` commit — already landed in #270, so that half was dropped as superseded.

> [!NOTE]
> **`fix/workflow-session-attribution` was discarded, not landed.** Its PR (#219) was closed unmerged, and #221/#233 superseded it: `parentSessionIDFromPath`'s walk-up, `resolveParentID`'s in-content sessionId precedence, `pendingParentLinks`, `repo.SourceRank()`/`SourceGitToplevel`/`SourceGitRemote` and `session.RepoSourceRank()` are **all already on main** — the pipeline comments are word-for-word identical. Merging it produced conflicts in 5 files with **zero net change**, and main's `applyRepoResolution` has since gained a 4th `parentRepoID` parameter implementing parent-inheritance that the old branch predates, so landing it would have regressed attribution. That branch can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)